### PR TITLE
Add Flutter scaffold for shared payment calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # PaymentCalendar
-カレンダーで支払いが確認できるようにする
+
+Flutter app that lets families or groups manage shared expenses in a calendar format.
+
+## Features
+- Calendar view showing total amount, who spent, and paid status
+- Expense input form with date, amount, category, member, and payment checkbox
+- Day detail and unpaid list screens for checking and toggling payments
+- Monthly summary by category and simple settings for members and categories

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'providers/expense_provider.dart';
+import 'screens/home_screen.dart';
+import 'screens/unpaid_screen.dart';
+import 'screens/summary_screen.dart';
+import 'screens/settings_screen.dart';
+
+void main() {
+  runApp(ChangeNotifierProvider(
+    create: (_) => ExpenseProvider(),
+    child: const PaymentCalendarApp(),
+  ));
+}
+
+class PaymentCalendarApp extends StatelessWidget {
+  const PaymentCalendarApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Payment Calendar',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const RootPage(),
+    );
+  }
+}
+
+class RootPage extends StatefulWidget {
+  const RootPage({Key? key}) : super(key: key);
+
+  @override
+  State<RootPage> createState() => _RootPageState();
+}
+
+class _RootPageState extends State<RootPage> {
+  int _index = 0;
+  final _screens = const [
+    HomeScreen(),
+    UnpaidScreen(),
+    SummaryScreen(),
+    SettingsScreen(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _screens[_index],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _index,
+        onTap: (i) => setState(() => _index = i),
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'ホーム'),
+          BottomNavigationBarItem(icon: Icon(Icons.error_outline), label: '未払い'),
+          BottomNavigationBarItem(icon: Icon(Icons.bar_chart), label: 'サマリー'),
+          BottomNavigationBarItem(icon: Icon(Icons.settings), label: '設定'),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/models/expense.dart
+++ b/lib/models/expense.dart
@@ -1,0 +1,22 @@
+class Expense {
+  Expense({
+    required this.date,
+    required this.amount,
+    required this.category,
+    required this.person,
+    this.isPaid = false,
+  });
+
+  DateTime date;
+  int amount;
+  String category;
+  String person;
+  bool isPaid;
+}
+
+class Member {
+  Member({required this.name, required this.icon});
+
+  String name;
+  String icon;
+}

--- a/lib/providers/expense_provider.dart
+++ b/lib/providers/expense_provider.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/foundation.dart';
+import 'package:table_calendar/table_calendar.dart';
+import '../models/expense.dart';
+
+class ExpenseProvider extends ChangeNotifier {
+  final List<Expense> _expenses = [];
+
+  final List<Member> members = [
+    Member(name: '母', icon: '👩'),
+    Member(name: '父', icon: '👨'),
+    Member(name: 'キャラ', icon: '🐱'),
+  ];
+
+  final List<String> categories = ['食費', '交通費', '娯楽費'];
+
+  List<Expense> get expenses => List.unmodifiable(_expenses);
+
+  void addExpense(Expense expense) {
+    _expenses.add(expense);
+    notifyListeners();
+  }
+
+  void togglePaid(Expense expense) {
+    expense.isPaid = !expense.isPaid;
+    notifyListeners();
+  }
+
+  List<Expense> expensesOn(DateTime day) =>
+      _expenses.where((e) => isSameDay(e.date, day)).toList();
+
+  Map<String, int> monthlySummary(DateTime month) {
+    final Map<String, int> data = {
+      for (final c in categories) c: 0,
+    };
+    for (final e in _expenses) {
+      if (e.date.year == month.year && e.date.month == month.month) {
+        data[e.category] = (data[e.category] ?? 0) + e.amount;
+      }
+    }
+    return data;
+  }
+
+  List<Expense> unpaidExpenses() =>
+      _expenses.where((e) => !e.isPaid).toList();
+}

--- a/lib/screens/day_detail_screen.dart
+++ b/lib/screens/day_detail_screen.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
+import '../providers/expense_provider.dart';
+
+class DayDetailScreen extends StatelessWidget {
+  const DayDetailScreen({Key? key, required this.day}) : super(key: key);
+
+  final DateTime day;
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<ExpenseProvider>();
+    final expenses = provider.expensesOn(day);
+    return Scaffold(
+      appBar: AppBar(title: Text(DateFormat.yMd().format(day))),
+      body: ListView.builder(
+        itemCount: expenses.length,
+        itemBuilder: (context, i) {
+          final e = expenses[i];
+          return ListTile(
+            title: Text('${e.amount}円｜${e.category}｜${e.person}'),
+            trailing: Checkbox(
+              value: e.isPaid,
+              onChanged: (_) => provider.togglePaid(e),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/expense_input_screen.dart
+++ b/lib/screens/expense_input_screen.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
+import '../providers/expense_provider.dart';
+import '../models/expense.dart';
+
+class ExpenseInputScreen extends StatefulWidget {
+  const ExpenseInputScreen({Key? key}) : super(key: key);
+
+  @override
+  State<ExpenseInputScreen> createState() => _ExpenseInputScreenState();
+}
+
+class _ExpenseInputScreenState extends State<ExpenseInputScreen> {
+  DateTime _date = DateTime.now();
+  final _amountController = TextEditingController();
+  String? _category;
+  Member? _member;
+  bool _isPaid = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.read<ExpenseProvider>();
+    _category ??= provider.categories.first;
+    _member ??= provider.members.first;
+    return Scaffold(
+      appBar: AppBar(title: const Text('支出入力')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: [
+            ListTile(
+              title: const Text('日付'),
+              subtitle: Text(DateFormat.yMd().format(_date)),
+              trailing: IconButton(
+                icon: const Icon(Icons.calendar_today),
+                onPressed: () async {
+                  final picked = await showDatePicker(
+                    context: context,
+                    initialDate: _date,
+                    firstDate: DateTime(2020),
+                    lastDate: DateTime(2030),
+                  );
+                  if (picked != null) {
+                    setState(() => _date = picked);
+                  }
+                },
+              ),
+            ),
+            TextField(
+              controller: _amountController,
+              decoration: const InputDecoration(labelText: '金額'),
+              keyboardType: TextInputType.number,
+            ),
+            DropdownButtonFormField<String>(
+              value: _category,
+              items: provider.categories
+                  .map((c) => DropdownMenuItem(value: c, child: Text(c)))
+                  .toList(),
+              onChanged: (v) => setState(() => _category = v),
+              decoration: const InputDecoration(labelText: '項目'),
+            ),
+            DropdownButtonFormField<Member>(
+              value: _member,
+              items: provider.members
+                  .map((m) => DropdownMenuItem(
+                        value: m,
+                        child: Text('${m.icon} ${m.name}'),
+                      ))
+                  .toList(),
+              onChanged: (m) => setState(() => _member = m),
+              decoration: const InputDecoration(labelText: '使った人'),
+            ),
+            CheckboxListTile(
+              title: const Text('支払い済み'),
+              value: _isPaid,
+              onChanged: (v) => setState(() => _isPaid = v ?? false),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                final amount = int.tryParse(_amountController.text) ?? 0;
+                if (amount > 0 && _category != null && _member != null) {
+                  provider.addExpense(Expense(
+                    date: _date,
+                    amount: amount,
+                    category: _category!,
+                    person: '${_member!.icon}${_member!.name}',
+                    isPaid: _isPaid,
+                  ));
+                  Navigator.pop(context);
+                }
+              },
+              child: const Text('保存'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:table_calendar/table_calendar.dart';
+import '../providers/expense_provider.dart';
+import 'expense_input_screen.dart';
+import 'day_detail_screen.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({Key? key}) : super(key: key);
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  DateTime _focusedDay = DateTime.now();
+  DateTime? _selectedDay;
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<ExpenseProvider>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('カレンダー')),
+      body: TableCalendar(
+        firstDay: DateTime.utc(2020, 1, 1),
+        lastDay: DateTime.utc(2030, 12, 31),
+        focusedDay: _focusedDay,
+        selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
+        onDaySelected: (selectedDay, focusedDay) {
+          setState(() {
+            _selectedDay = selectedDay;
+            _focusedDay = focusedDay;
+          });
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => DayDetailScreen(day: selectedDay)),
+          );
+        },
+        calendarBuilders: CalendarBuilders(
+          markerBuilder: (context, date, events) {
+            final expenses = provider.expensesOn(date);
+            if (expenses.isEmpty) return const SizedBox();
+            final total =
+                expenses.fold<int>(0, (prev, e) => prev + e.amount);
+            final icons =
+                expenses.map((e) => e.person).toSet().join();
+            final paid = expenses.every((e) => e.isPaid);
+            return Column(
+              children: [
+                Text('¥$total', style: const TextStyle(fontSize: 10)),
+                Text(icons, style: const TextStyle(fontSize: 12)),
+                Icon(
+                  paid ? Icons.check_box : Icons.check_box_outline_blank,
+                  size: 12,
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const ExpenseInputScreen()),
+        ),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/expense_provider.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<ExpenseProvider>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('設定')),
+      body: ListView(
+        children: [
+          ListTile(
+            title: const Text('カテゴリ'),
+            subtitle: Wrap(
+              spacing: 8,
+              children: provider.categories
+                  .map((c) => Chip(label: Text(c)))
+                  .toList(),
+            ),
+          ),
+          ListTile(
+            title: const Text('メンバー'),
+            subtitle: Wrap(
+              spacing: 8,
+              children: provider.members
+                  .map((m) => Chip(label: Text('${m.icon} ${m.name}')))
+                  .toList(),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/summary_screen.dart
+++ b/lib/screens/summary_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/expense_provider.dart';
+
+class SummaryScreen extends StatelessWidget {
+  const SummaryScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<ExpenseProvider>();
+    final month = DateTime.now();
+    final summary = provider.monthlySummary(month);
+    return Scaffold(
+      appBar: AppBar(title: const Text('サマリー')),
+      body: ListView(
+        children: summary.entries
+            .map(
+              (e) => ListTile(
+                title: Text(e.key),
+                trailing: Text('${e.value}円'),
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+}

--- a/lib/screens/unpaid_screen.dart
+++ b/lib/screens/unpaid_screen.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
+import '../providers/expense_provider.dart';
+
+class UnpaidScreen extends StatelessWidget {
+  const UnpaidScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<ExpenseProvider>();
+    final unpaid = provider.unpaidExpenses();
+    return Scaffold(
+      appBar: AppBar(title: const Text('未払い一覧')),
+      body: ListView.builder(
+        itemCount: unpaid.length,
+        itemBuilder: (context, i) {
+          final e = unpaid[i];
+          return ListTile(
+            title: Text(
+                '${DateFormat.Md().format(e.date)}｜${e.person}｜${e.category}｜${e.amount}円'),
+            trailing: Checkbox(
+              value: e.isPaid,
+              onChanged: (_) => provider.togglePaid(e),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,16 @@
+name: payment_calendar
+description: A Flutter app for shared payment tracking.
+version: 1.0.0+1
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  table_calendar: ^3.0.8
+  provider: ^6.0.5
+  intl: ^0.18.0
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- scaffold Flutter app with calendar-based expense tracking
- add forms and lists for adding, viewing, and managing shared payments

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd935204e8833287254b2e48adc559