### PR TITLE
Revamp home screen with inline expense list and member icons

### DIFF
--- a/lib/models/expense.dart
+++ b/lib/models/expense.dart
@@ -4,6 +4,7 @@ class Expense {
     required this.amount,
     required this.category,
     required this.person,
+    required this.personIcon,
     this.isPaid = false,
   });
 
@@ -11,6 +12,7 @@ class Expense {
   int amount;
   String category;
   String person;
+  String personIcon;
   bool isPaid;
 }
 

--- a/lib/screens/day_detail_screen.dart
+++ b/lib/screens/day_detail_screen.dart
@@ -19,7 +19,7 @@ class DayDetailScreen extends StatelessWidget {
         itemBuilder: (context, i) {
           final e = expenses[i];
           return ListTile(
-            title: Text('${e.amount}円｜${e.category}｜${e.person}'),
+            title: Text('${e.amount}円｜${e.category}｜${e.personIcon}${e.person}'),
             trailing: Checkbox(
               value: e.isPaid,
               onChanged: (_) => provider.togglePaid(e),

--- a/lib/screens/expense_input_screen.dart
+++ b/lib/screens/expense_input_screen.dart
@@ -84,7 +84,8 @@ class _ExpenseInputScreenState extends State<ExpenseInputScreen> {
                     date: _date,
                     amount: amount,
                     category: _category!,
-                    person: '${_member!.icon}${_member!.name}',
+                    person: _member!.name,
+                    personIcon: _member!.icon,
                     isPaid: _isPaid,
                   ));
                   Navigator.pop(context);

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:table_calendar/table_calendar.dart';
 import '../providers/expense_provider.dart';
+import '../models/expense.dart';
 import 'expense_input_screen.dart';
-import 'day_detail_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({Key? key}) : super(key: key);
@@ -13,50 +13,149 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
+  CalendarFormat _calendarFormat = CalendarFormat.month;
   DateTime _focusedDay = DateTime.now();
   DateTime? _selectedDay;
+
+  int _totalAmountForDay(List<Expense> expenses) =>
+      expenses.fold(0, (sum, e) => sum + e.amount);
+
+  String _iconFor(Expense e) => String.fromCharCode(e.personIcon.runes.first);
 
   @override
   Widget build(BuildContext context) {
     final provider = context.watch<ExpenseProvider>();
+    final dayExpenses =
+        _selectedDay != null ? provider.expensesOn(_selectedDay!) : <Expense>[];
     return Scaffold(
       appBar: AppBar(title: const Text('カレンダー')),
-      body: TableCalendar(
-        firstDay: DateTime.utc(2020, 1, 1),
-        lastDay: DateTime.utc(2030, 12, 31),
-        focusedDay: _focusedDay,
-        selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
-        onDaySelected: (selectedDay, focusedDay) {
-          setState(() {
-            _selectedDay = selectedDay;
-            _focusedDay = focusedDay;
-          });
-          Navigator.push(
-            context,
-            MaterialPageRoute(builder: (_) => DayDetailScreen(day: selectedDay)),
-          );
-        },
-        calendarBuilders: CalendarBuilders(
-          markerBuilder: (context, date, events) {
-            final expenses = provider.expensesOn(date);
-            if (expenses.isEmpty) return const SizedBox();
-            final total =
-                expenses.fold<int>(0, (prev, e) => prev + e.amount);
-            final icons =
-                expenses.map((e) => e.person).toSet().join();
-            final paid = expenses.every((e) => e.isPaid);
-            return Column(
-              children: [
-                Text('¥$total', style: const TextStyle(fontSize: 10)),
-                Text(icons, style: const TextStyle(fontSize: 12)),
-                Icon(
-                  paid ? Icons.check_box : Icons.check_box_outline_blank,
-                  size: 12,
+      body: Column(
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              color: Colors.blue[600],
+              borderRadius: const BorderRadius.only(
+                bottomLeft: Radius.circular(20),
+                bottomRight: Radius.circular(20),
+              ),
+            ),
+            child: TableCalendar<Expense>(
+              firstDay: DateTime.utc(2020, 1, 1),
+              lastDay: DateTime.utc(2030, 12, 31),
+              focusedDay: _focusedDay,
+              calendarFormat: _calendarFormat,
+              eventLoader: provider.expensesOn,
+              startingDayOfWeek: StartingDayOfWeek.sunday,
+              selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
+              onDaySelected: (selectedDay, focusedDay) {
+                setState(() {
+                  _selectedDay = selectedDay;
+                  _focusedDay = focusedDay;
+                });
+              },
+              onFormatChanged: (format) {
+                if (_calendarFormat != format) {
+                  setState(() => _calendarFormat = format);
+                }
+              },
+              onPageChanged: (focusedDay) => _focusedDay = focusedDay,
+              calendarStyle: CalendarStyle(
+                outsideDaysVisible: false,
+                weekendTextStyle: const TextStyle(color: Colors.white70),
+                holidayTextStyle: const TextStyle(color: Colors.white70),
+                defaultTextStyle: const TextStyle(color: Colors.white),
+                selectedTextStyle: TextStyle(color: Colors.blue[600]),
+                todayTextStyle: TextStyle(color: Colors.blue[600]),
+                selectedDecoration: const BoxDecoration(
+                  color: Colors.white,
+                  shape: BoxShape.circle,
                 ),
-              ],
-            );
-          },
-        ),
+                todayDecoration: const BoxDecoration(
+                  color: Colors.white70,
+                  shape: BoxShape.circle,
+                ),
+                markerDecoration: const BoxDecoration(
+                  color: Colors.orange,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              headerStyle: HeaderStyle(
+                formatButtonVisible: true,
+                titleCentered: true,
+                formatButtonShowsNext: false,
+                formatButtonDecoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(12.0),
+                ),
+                formatButtonTextStyle: TextStyle(color: Colors.blue[600]),
+                leftChevronIcon:
+                    const Icon(Icons.chevron_left, color: Colors.white),
+                rightChevronIcon:
+                    const Icon(Icons.chevron_right, color: Colors.white),
+                titleTextStyle: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              calendarBuilders: CalendarBuilders(
+                markerBuilder: (context, date, _) {
+                  final expenses = provider.expensesOn(date);
+                  if (expenses.isEmpty) return null;
+                  final total = _totalAmountForDay(expenses);
+                  final icons = expenses
+                      .map(_iconFor)
+                      .toSet()
+                      .take(3)
+                      .toList();
+                  final anyUnpaid = expenses.any((e) => !e.isPaid);
+                  return Container(
+                    margin: const EdgeInsets.only(top: 5),
+                    child: Column(
+                      children: [
+                        Text('¥$total',
+                            style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 10,
+                                fontWeight: FontWeight.bold)),
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            for (final icon in icons)
+                              Container(
+                                margin: const EdgeInsets.symmetric(horizontal: 1),
+                                child: Text(icon,
+                                    style: const TextStyle(fontSize: 8)),
+                              ),
+                            Container(
+                              margin:
+                                  const EdgeInsets.symmetric(horizontal: 1),
+                              child: Text(
+                                anyUnpaid ? '□' : '☑️',
+                                style: const TextStyle(fontSize: 8),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+          Expanded(
+            child: _selectedDay == null
+                ? Center(
+                    child: Text(
+                      '日付を選択して詳細を確認してください',
+                      style:
+                          TextStyle(fontSize: 16, color: Colors.grey[600]),
+                    ),
+                  )
+                : _buildExpenseList(dayExpenses, provider),
+          ),
+        ],
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => Navigator.push(
@@ -65,6 +164,56 @@ class _HomeScreenState extends State<HomeScreen> {
         ),
         child: const Icon(Icons.add),
       ),
+    );
+  }
+
+  Widget _buildExpenseList(List<Expense> expenses, ExpenseProvider provider) {
+    if (expenses.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.receipt, size: 64, color: Colors.grey[400]),
+            const SizedBox(height: 16),
+            Text(
+              'この日の支出はありません',
+              style: TextStyle(fontSize: 16, color: Colors.grey[600]),
+            ),
+          ],
+        ),
+      );
+    }
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: expenses.length,
+      itemBuilder: (context, index) {
+        final e = expenses[index];
+        return Card(
+          elevation: 2,
+          margin: const EdgeInsets.only(bottom: 8),
+          child: ListTile(
+            leading: CircleAvatar(
+              backgroundColor: Colors.blue[100],
+              child: Text(
+                _iconFor(e),
+                style: const TextStyle(fontSize: 20),
+              ),
+            ),
+            title: Text('¥${e.amount}',
+                style: const TextStyle(
+                    fontWeight: FontWeight.bold, fontSize: 18)),
+            subtitle: Text('${e.category} | ${e.person}'),
+            trailing: GestureDetector(
+              onTap: () => provider.togglePaid(e),
+              child: Container(
+                padding: const EdgeInsets.all(8),
+                child: Text(e.isPaid ? '☑️' : '□',
+                    style: const TextStyle(fontSize: 24)),
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/screens/unpaid_screen.dart
+++ b/lib/screens/unpaid_screen.dart
@@ -18,7 +18,7 @@ class UnpaidScreen extends StatelessWidget {
           final e = unpaid[i];
           return ListTile(
             title: Text(
-                '${DateFormat.Md().format(e.date)}｜${e.person}｜${e.category}｜${e.amount}円'),
+                '${DateFormat.Md().format(e.date)}｜${e.personIcon}${e.person}｜${e.category}｜${e.amount}円'),
             trailing: Checkbox(
               value: e.isPaid,
               onChanged: (_) => provider.togglePaid(e),


### PR DESCRIPTION
## Summary
- separate member icon from name in Expense model
- collect member info in expense input and display icon+name in lists
- redesign home screen: blue header calendar with markers, inline day expense list with paid toggle

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be5e77ed748332b3bc9841c5804fa7