### PR TITLE
feat: enhance expense input screen

### DIFF
--- a/lib/providers/expense_provider.dart
+++ b/lib/providers/expense_provider.dart
@@ -8,10 +8,19 @@ class ExpenseProvider extends ChangeNotifier {
   final List<Member> members = [
     Member(name: '母', icon: '👩'),
     Member(name: '父', icon: '👨'),
-    Member(name: 'キャラ', icon: '🐱'),
+    Member(name: '子', icon: '👶'),
+    Member(name: 'その他', icon: '👤'),
   ];
 
-  final List<String> categories = ['食費', '交通費', '娯楽費'];
+  final List<String> categories = [
+    '食費',
+    '交通費',
+    '娯楽費',
+    '医療費',
+    '日用品',
+    '光熱費',
+    'その他',
+  ];
 
   List<Expense> get expenses => List.unmodifiable(_expenses);
 

--- a/lib/screens/expense_input_screen.dart
+++ b/lib/screens/expense_input_screen.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
-import '../providers/expense_provider.dart';
+
 import '../models/expense.dart';
+import '../providers/expense_provider.dart';
 
 class ExpenseInputScreen extends StatefulWidget {
   const ExpenseInputScreen({Key? key}) : super(key: key);
@@ -12,89 +13,332 @@ class ExpenseInputScreen extends StatefulWidget {
 }
 
 class _ExpenseInputScreenState extends State<ExpenseInputScreen> {
-  DateTime _date = DateTime.now();
+  final _formKey = GlobalKey<FormState>();
   final _amountController = TextEditingController();
-  String? _category;
-  Member? _member;
+
+  DateTime _selectedDate = DateTime.now();
+  late String _selectedCategory;
+  late Member _selectedMember;
   bool _isPaid = false;
+
+  final Map<String, String> _categoryIcons = const {
+    '食費': '🍽️',
+    '交通費': '🚃',
+    '娯楽費': '🎮',
+    '医療費': '🏥',
+    '日用品': '🧽',
+    '光熱費': '💡',
+    'その他': '📝',
+  };
+
+  @override
+  void initState() {
+    super.initState();
+    final provider = context.read<ExpenseProvider>();
+    _selectedCategory = provider.categories.first;
+    _selectedMember = provider.members.first;
+  }
+
+  @override
+  void dispose() {
+    _amountController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate,
+      firstDate: DateTime(2020),
+      lastDate: DateTime(2030),
+    );
+    if (picked != null) {
+      setState(() => _selectedDate = picked);
+    }
+  }
+
+  void _save() {
+    if (_formKey.currentState!.validate()) {
+      final provider = context.read<ExpenseProvider>();
+      final amount = int.parse(_amountController.text);
+      provider.addExpense(Expense(
+        date: _selectedDate,
+        amount: amount,
+        category: _selectedCategory,
+        person: '${_selectedMember.icon}${_selectedMember.name}',
+        isPaid: _isPaid,
+      ));
+      Navigator.pop(context);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('支出を追加しました')),
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    final provider = context.read<ExpenseProvider>();
-    _category ??= provider.categories.first;
-    _member ??= provider.members.first;
+    final provider = context.watch<ExpenseProvider>();
+    final categories = provider.categories;
+    final members = provider.members;
+
     return Scaffold(
-      appBar: AppBar(title: const Text('支出入力')),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: ListView(
-          children: [
-            ListTile(
-              title: const Text('日付'),
-              subtitle: Text(DateFormat.yMd().format(_date)),
-              trailing: IconButton(
-                icon: const Icon(Icons.calendar_today),
-                onPressed: () async {
-                  final picked = await showDatePicker(
-                    context: context,
-                    initialDate: _date,
-                    firstDate: DateTime(2020),
-                    lastDate: DateTime(2030),
-                  );
-                  if (picked != null) {
-                    setState(() => _date = picked);
-                  }
-                },
-              ),
+      appBar: AppBar(
+        title: const Text('支出を追加'),
+        actions: [
+          TextButton(
+            onPressed: _save,
+            child: const Text(
+              '保存',
+              style: TextStyle(color: Colors.white),
             ),
-            TextField(
-              controller: _amountController,
-              decoration: const InputDecoration(labelText: '金額'),
-              keyboardType: TextInputType.number,
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Card(
+                  child: ListTile(
+                    leading: const Icon(Icons.calendar_today),
+                    title: const Text('日付'),
+                    subtitle:
+                        Text(DateFormat.yMd('ja').format(_selectedDate)),
+                    onTap: _pickDate,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: TextFormField(
+                      controller: _amountController,
+                      keyboardType: TextInputType.number,
+                      decoration: const InputDecoration(
+                        labelText: '金額',
+                        prefixText: '¥',
+                        border: OutlineInputBorder(),
+                      ),
+                      validator: (v) {
+                        if (v == null || v.isEmpty) {
+                          return '金額を入力してください';
+                        }
+                        if (int.tryParse(v) == null) {
+                          return '有効な数字を入力してください';
+                        }
+                        return null;
+                      },
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: const [
+                            Icon(Icons.category),
+                            SizedBox(width: 8),
+                            Text('カテゴリ'),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        GridView.builder(
+                          shrinkWrap: true,
+                          physics: const NeverScrollableScrollPhysics(),
+                          gridDelegate:
+                              const SliverGridDelegateWithFixedCrossAxisCount(
+                            crossAxisCount: 4,
+                            childAspectRatio: 1,
+                            crossAxisSpacing: 8,
+                            mainAxisSpacing: 8,
+                          ),
+                          itemCount: categories.length,
+                          itemBuilder: (context, index) {
+                            final category = categories[index];
+                            final icon = _categoryIcons[category] ?? '📝';
+                            final isSelected = category == _selectedCategory;
+                            return GestureDetector(
+                              onTap: () =>
+                                  setState(() => _selectedCategory = category),
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  color: isSelected
+                                      ? Colors.blue[600]
+                                      : Colors.grey[100],
+                                  borderRadius: BorderRadius.circular(8),
+                                  border: Border.all(
+                                    color: isSelected
+                                        ? Colors.blue[600]!
+                                        : Colors.grey[300]!,
+                                  ),
+                                ),
+                                child: Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Text(icon, style: const TextStyle(fontSize: 20)),
+                                    const SizedBox(height: 4),
+                                    Text(
+                                      category,
+                                      style: TextStyle(
+                                        fontSize: 10,
+                                        color: isSelected
+                                            ? Colors.white
+                                            : Colors.black87,
+                                        fontWeight: isSelected
+                                            ? FontWeight.bold
+                                            : FontWeight.normal,
+                                      ),
+                                      textAlign: TextAlign.center,
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: const [
+                            Icon(Icons.person),
+                            SizedBox(width: 8),
+                            Text('使った人'),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        Row(
+                          children: members.map((m) {
+                            final isSelected = m == _selectedMember;
+                            return Expanded(
+                              child: GestureDetector(
+                                onTap: () => setState(() => _selectedMember = m),
+                                child: Container(
+                                  margin:
+                                      const EdgeInsets.symmetric(horizontal: 4),
+                                  padding:
+                                      const EdgeInsets.symmetric(vertical: 12),
+                                  decoration: BoxDecoration(
+                                    color: isSelected
+                                        ? Colors.purple[600]
+                                        : Colors.grey[100],
+                                    borderRadius: BorderRadius.circular(8),
+                                    border: Border.all(
+                                      color: isSelected
+                                          ? Colors.purple[600]!
+                                          : Colors.grey[300]!,
+                                    ),
+                                  ),
+                                  child: Column(
+                                    children: [
+                                      Text(m.icon, style: const TextStyle(fontSize: 24)),
+                                      const SizedBox(height: 4),
+                                      Text(
+                                        m.name,
+                                        style: TextStyle(
+                                          fontSize: 12,
+                                          color: isSelected
+                                              ? Colors.white
+                                              : Colors.black87,
+                                          fontWeight: isSelected
+                                              ? FontWeight.bold
+                                              : FontWeight.normal,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                            );
+                          }).toList(),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      children: [
+                        const Icon(Icons.payment, color: Colors.red, size: 24),
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              const Text(
+                                '支払い状況',
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                              const SizedBox(height: 4),
+                              Text(
+                                _isPaid ? '支払い済み' : '未払い',
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  color: _isPaid
+                                      ? Colors.green[600]
+                                      : Colors.red[600],
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        Switch(
+                          value: _isPaid,
+                          onChanged: (v) => setState(() => _isPaid = v),
+                          activeColor: Colors.green[600],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 32),
+                ElevatedButton(
+                  onPressed: _save,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.blue[600],
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Text(
+                    '支出を保存',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              ],
             ),
-            DropdownButtonFormField<String>(
-              value: _category,
-              items: provider.categories
-                  .map((c) => DropdownMenuItem(value: c, child: Text(c)))
-                  .toList(),
-              onChanged: (v) => setState(() => _category = v),
-              decoration: const InputDecoration(labelText: '項目'),
-            ),
-            DropdownButtonFormField<Member>(
-              value: _member,
-              items: provider.members
-                  .map((m) => DropdownMenuItem(
-                        value: m,
-                        child: Text('${m.icon} ${m.name}'),
-                      ))
-                  .toList(),
-              onChanged: (m) => setState(() => _member = m),
-              decoration: const InputDecoration(labelText: '使った人'),
-            ),
-            CheckboxListTile(
-              title: const Text('支払い済み'),
-              value: _isPaid,
-              onChanged: (v) => setState(() => _isPaid = v ?? false),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                final amount = int.tryParse(_amountController.text) ?? 0;
-                if (amount > 0 && _category != null && _member != null) {
-                  provider.addExpense(Expense(
-                    date: _date,
-                    amount: amount,
-                    category: _category!,
-                    person: '${_member!.icon}${_member!.name}',
-                    isPaid: _isPaid,
-                  ));
-                  Navigator.pop(context);
-                }
-              },
-              child: const Text('保存'),
-            )
-          ],
+          ),
         ),
       ),
     );
   }
 }
+


### PR DESCRIPTION
## Summary
- expand member and category lists to cover more options
- redesign expense input screen with category icons and member selection

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be5ec4700c833290498dbe9e5baecb