### PR TITLE
Fix widget test to use PaymentCalendarApp

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:payment_calendar/main.dart';
+import 'package:payment_calendar/providers/settings_provider.dart';
+import 'package:payment_calendar/services/reminder_service.dart';
+
+class _FakeReminderService implements ReminderService {
+  @override
+  Future<void> cancelAll() async {}
+
+  @override
+  Future<void> cancelPlannedReminder() async {}
+
+  @override
+  Future<void> cancelUnpaidReminder() async {}
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> scheduleDailyUnpaidReminder() async {}
+
+  @override
+  Future<void> schedulePlannedReminder() async {}
+}
+
+void main() {
+  testWidgets('PaymentCalendarApp can be pumped', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          reminderServiceProvider.overrideWithValue(_FakeReminderService()),
+        ],
+        child: const PaymentCalendarApp(),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MaterialApp), findsOneWidget);
+    expect(find.text('ホーム'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add a widget test that pumps `PaymentCalendarApp` instead of the removed `MyApp`
- provide a fake `ReminderService` for the test to satisfy the Riverpod override

## Testing
- flutter test *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d233cedea48332a3dec33399aabdcf