### PR TITLE
Fix helper methods in expense detail screen

### DIFF
--- a/lib/screens/expense/expense_detail_screen.dart
+++ b/lib/screens/expense/expense_detail_screen.dart
@@ -209,7 +209,8 @@ class ExpenseDetailScreen extends ConsumerWidget {
     );
     if (picked != null) {
       ref.read(expensesProvider.notifier).changeDate(expenseId, picked);
-}
+    }
+  }
 
   Widget _buildImage(String path) {
     final file = File(path);
@@ -225,7 +226,6 @@ class ExpenseDetailScreen extends ConsumerWidget {
       fit: BoxFit.cover,
     );
   }
-}
 
   void _openPhoto(BuildContext context, String path) {
     Navigator.of(context).push(


### PR DESCRIPTION
## Summary
- close the change due date helper properly to keep the widget class well-formed
- keep the image builder and photo navigation helpers inside the `ExpenseDetailScreen`

## Testing
- dart analyze *(fails: dart not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d23aef4f308332bb9017c85919c4bb