### PR TITLE
Fix nullability issues in expense detail screen

### DIFF
--- a/lib/screens/expense/expense_detail_screen.dart
+++ b/lib/screens/expense/expense_detail_screen.dart
@@ -19,31 +19,33 @@ class ExpenseDetailScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final expenses = ref.watch(expensesProvider);
-    Expense? expense;
+    Expense? expenseNullable;
     for (final item in expenses) {
       if (item.id == expenseId) {
-        expense = item;
+        expenseNullable = item;
         break;
       }
     }
-    if (expense == null) {
+    if (expenseNullable == null) {
       return const Scaffold(
         body: Center(child: Text('明細が見つかりませんでした')),
       );
     }
+    final expense = expenseNullable!;
     final people = ref.watch(peopleProvider);
-    Person? person;
+    Person? personNullable;
     for (final p in people) {
       if (p.id == expense.personId) {
-        person = p;
+        personNullable = p;
         break;
       }
     }
-    if (person == null) {
+    if (personNullable == null) {
       return const Scaffold(
         body: Center(child: Text('人の情報が見つかりませんでした')),
       );
     }
+    final person = personNullable!;
     return Scaffold(
       appBar: AppBar(
         title: const Text('明細'),


### PR DESCRIPTION
## Summary
- ensure the retrieved expense is converted to a non-nullable value before use
- ensure the related person lookup also produces a non-nullable value

## Testing
- not run (dart command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d25efd373083329d8dd65bc598b829