### PR TITLE
Refactor expense provider to match current models

### DIFF
--- a/lib/providers/expense_provider.dart
+++ b/lib/providers/expense_provider.dart
@@ -1,17 +1,18 @@
 import 'package:flutter/foundation.dart';
-import 'package:table_calendar/table_calendar.dart';
+
 import '../models/expense.dart';
+import '../models/person.dart';
 
 class ExpenseProvider extends ChangeNotifier {
+  ExpenseProvider();
+
   final List<Expense> _expenses = [];
 
-  final List<Member> members = [
-    Member(name: '母', icon: '👩'),
-    Member(name: '父', icon: '👨'),
-    Member(name: 'キャラ', icon: '🐱'),
+  final List<Person> members = const [
+    Person(id: 'mother', name: '母', emoji: '👩'),
+    Person(id: 'father', name: '父', emoji: '👨'),
+    Person(id: 'pet', name: 'キャラ', emoji: '🐱'),
   ];
-
-  final List<String> categories = ['食費', '交通費', '娯楽費'];
 
   List<Expense> get expenses => List.unmodifiable(_expenses);
 
@@ -21,30 +22,58 @@ class ExpenseProvider extends ChangeNotifier {
   }
 
   void removeExpense(Expense expense) {
-    _expenses.remove(expense);
+    _expenses.removeWhere((element) => element.id == expense.id);
     notifyListeners();
   }
 
   void togglePaid(Expense expense) {
-    expense.isPaid = !expense.isPaid;
+    final index = _expenses.indexWhere((element) => element.id == expense.id);
+    if (index == -1) {
+      return;
+    }
+    final current = _expenses[index];
+    _expenses[index] = current.adjustStatus(paid: !current.isPaid);
     notifyListeners();
   }
 
-  List<Expense> expensesOn(DateTime day) =>
-      _expenses.where((e) => isSameDay(e.date, day)).toList();
-
-  Map<String, int> monthlySummary(DateTime month) {
-    final Map<String, int> data = {
-      for (final c in categories) c: 0,
-    };
-    for (final e in _expenses) {
-      if (e.date.year == month.year && e.date.month == month.month) {
-        data[e.category] = (data[e.category] ?? 0) + e.amount;
-      }
-    }
-    return data;
+  List<Expense> expensesOn(DateTime day) {
+    return _expenses.where((expense) => _isSameDay(expense.date, day)).toList();
   }
 
-  List<Expense> unpaidExpenses() =>
-      _expenses.where((e) => !e.isPaid).toList();
+  Map<String, int> monthlySummary(DateTime month) {
+    final summary = <String, int>{
+      for (final member in members) member.name: 0,
+    };
+
+    for (final expense in _expenses) {
+      if (expense.date.year == month.year &&
+          expense.date.month == month.month) {
+        final memberName = _memberNameFor(expense.personId) ?? expense.personId;
+        summary.update(
+          memberName,
+          (value) => value + expense.amount,
+          ifAbsent: () => expense.amount,
+        );
+      }
+    }
+
+    return summary;
+  }
+
+  List<Expense> unpaidExpenses() {
+    return _expenses.where((expense) => expense.isUnpaid).toList();
+  }
+
+  String? _memberNameFor(String personId) {
+    for (final member in members) {
+      if (member.id == personId) {
+        return member.name;
+      }
+    }
+    return null;
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the obsolete member stubs with concrete `Person` records used throughout the app
- update paid-state toggling and monthly aggregation to work with the immutable `Expense` model
- drop the unused table_calendar dependency by handling date comparisons locally

## Testing
- ⚠️ `flutter test` *(fails: `flutter` command is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d26936ebc483329cb6a210dfe2e584