### PR TITLE
Replace Equatable usage with manual equality implementations

### DIFF
--- a/lib/models/expense.dart
+++ b/lib/models/expense.dart
@@ -1,9 +1,9 @@
-import 'package:equatable/equatable.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 enum ExpenseStatus { unpaid, planned, paid }
 
-class Expense extends Equatable {
+class Expense {
   const Expense({
     required this.id,
     required this.personId,
@@ -103,15 +103,32 @@ class Expense extends Equatable {
   }
 
   @override
-  List<Object?> get props => [
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is Expense &&
+        other.id == id &&
+        other.personId == personId &&
+        other.date == date &&
+        other.amount == amount &&
+        other.memo == memo &&
+        other.status == status &&
+        listEquals(other.photoPaths, photoPaths) &&
+        other.paidAt == paidAt &&
+        other.createdAt == createdAt;
+  }
+
+  @override
+  int get hashCode => Object.hash(
         id,
         personId,
         date,
         amount,
         memo,
         status,
-        photoPaths,
+        Object.hashAll(photoPaths),
         paidAt,
         createdAt,
-      ];
+      );
 }

--- a/lib/models/person.dart
+++ b/lib/models/person.dart
@@ -1,6 +1,4 @@
-import 'package:equatable/equatable.dart';
-
-class Person extends Equatable {
+class Person {
   const Person({
     required this.id,
     required this.name,
@@ -27,5 +25,17 @@ class Person extends Equatable {
   }
 
   @override
-  List<Object?> get props => [id, name, photoPath, emoji];
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is Person &&
+        other.id == id &&
+        other.name == name &&
+        other.photoPath == photoPath &&
+        other.emoji == emoji;
+  }
+
+  @override
+  int get hashCode => Object.hash(id, name, photoPath, emoji);
 }

--- a/lib/models/person_summary.dart
+++ b/lib/models/person_summary.dart
@@ -1,8 +1,6 @@
-import 'package:equatable/equatable.dart';
-
 import 'person.dart';
 
-class PersonSummary extends Equatable {
+class PersonSummary {
   const PersonSummary({
     required this.person,
     required this.unpaidAmount,
@@ -24,11 +22,24 @@ class PersonSummary extends Equatable {
       includePlanned ? unpaidCount + plannedCount : unpaidCount;
 
   @override
-  List<Object?> get props => [
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is PersonSummary &&
+        other.person == person &&
+        other.unpaidAmount == unpaidAmount &&
+        other.unpaidCount == unpaidCount &&
+        other.plannedAmount == plannedAmount &&
+        other.plannedCount == plannedCount;
+  }
+
+  @override
+  int get hashCode => Object.hash(
         person,
         unpaidAmount,
         unpaidCount,
         plannedAmount,
         plannedCount,
-      ];
+      );
 }

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -1,6 +1,4 @@
-import 'package:equatable/equatable.dart';
-
-class SettingsState extends Equatable {
+class SettingsState {
   const SettingsState({
     this.reminderEnabled = false,
     this.plannedReminderEnabled = false,
@@ -26,9 +24,20 @@ class SettingsState extends Equatable {
   }
 
   @override
-  List<Object?> get props => [
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is SettingsState &&
+        other.reminderEnabled == reminderEnabled &&
+        other.plannedReminderEnabled == plannedReminderEnabled &&
+        other.quickPayIncludesPlanned == quickPayIncludesPlanned;
+  }
+
+  @override
+  int get hashCode => Object.hash(
         reminderEnabled,
         plannedReminderEnabled,
         quickPayIncludesPlanned,
-      ];
+      );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,14 +73,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
-  equatable:
-    dependency: "direct main"
-    description:
-      name: equatable
-      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.7"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,6 @@ dependencies:
   path_provider: ^2.0.12
   flutter_local_notifications: ^17.2.1
   timezone: ^0.9.2
-  equatable: ^2.0.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- remove the Equatable dependency from the project models
- implement explicit equality and hashCode overrides for Person, PersonSummary, Expense, and SettingsState
- adjust pubspec files to drop the unused package

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d28cf13c84833286c0b6bd058bb9fb