### PR TITLE
Replace NavigationBar with BottomNavigationBar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,13 +63,22 @@ class _RootPageState extends ConsumerState<RootPage> {
         index: _index,
         children: screens,
       ),
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: _index,
-        onDestinationSelected: (value) => setState(() => _index = value),
-        destinations: const [
-          NavigationDestination(icon: Icon(Icons.home), label: 'ホーム'),
-          NavigationDestination(icon: Icon(Icons.receipt_long), label: '未払い'),
-          NavigationDestination(icon: Icon(Icons.settings), label: '設定'),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _index,
+        onTap: (value) => setState(() => _index = value),
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.home),
+            label: 'ホーム',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.receipt_long),
+            label: '未払い',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.settings),
+            label: '設定',
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- replace the Material 3 NavigationBar with BottomNavigationBar to avoid missing widget errors on environments where NavigationBar is unavailable

## Testing
- not run (Flutter SDK is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d29f119fb0833297f63773bb023dc8