### PR TITLE
Replace unavailable ColorScheme background color

### DIFF
--- a/lib/screens/expense/expense_form_sheet.dart
+++ b/lib/screens/expense/expense_form_sheet.dart
@@ -293,9 +293,8 @@ class _ExpenseFormSheetState extends ConsumerState<ExpenseFormSheet> {
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color:
-              theme.colorScheme.surfaceContainerHighest.withOpacityValue(0.4),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface.withOpacityValue(0.4),
         borderRadius: BorderRadius.circular(12),
         border: Border.all(color: theme.dividerColor),
       ),

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -34,9 +34,8 @@ class HomeScreen extends ConsumerWidget {
         .select((settings) => settings.quickPayIncludesPlanned));
     final colorScheme = Theme.of(context).colorScheme;
 
-      return Scaffold(
-        backgroundColor:
-            colorScheme.surfaceContainerHighest.withOpacityValue(0.3),
+    return Scaffold(
+      backgroundColor: colorScheme.surface.withOpacityValue(0.3),
       appBar: AppBar(
         title: const Text('ホーム'),
         backgroundColor: colorScheme.surface,


### PR DESCRIPTION
## Summary
- replace the unsupported `ColorScheme.surfaceContainerHighest` getter with `surface` when computing background colors
- apply the same change to the new-person form container styling

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2d0039250833295a3805a7715176d