### PR TITLE
Fix flutter_riverpod imports

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod/flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'providers/settings_provider.dart';
 import 'screens/home/home_screen.dart';

--- a/lib/providers/expenses_provider.dart
+++ b/lib/providers/expenses_provider.dart
@@ -1,13 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod/flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
 
 import '../models/expense.dart';

--- a/lib/providers/home_summary_provider.dart
+++ b/lib/providers/home_summary_provider.dart
@@ -1,12 +1,4 @@
-import 'package:flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod/flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/expense.dart';
 import '../models/person.dart';

--- a/lib/providers/people_provider.dart
+++ b/lib/providers/people_provider.dart
@@ -1,12 +1,4 @@
-import 'package:flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod/flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
 
 import '../models/person.dart';

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -1,15 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod/flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/expense.dart';
 import '../models/settings.dart';

--- a/lib/screens/expense/expense_form_sheet.dart
+++ b/lib/screens/expense/expense_form_sheet.dart
@@ -1,15 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod/flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:payment_calendar/utils/color_utils.dart';

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1,15 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod/flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:payment_calendar/utils/color_utils.dart';
 
 import '../../models/expense.dart';

--- a/lib/screens/person/person_detail_screen.dart
+++ b/lib/screens/person/person_detail_screen.dart
@@ -1,13 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod/flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:payment_calendar/widgets/radio_option_tile.dart';
 
 import '../../models/expense.dart';

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -1,13 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod/flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../models/person.dart';
 import '../../providers/people_provider.dart';

--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -1,15 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod/flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:payment_calendar/widgets/radio_option_tile.dart';
 
 import '../../models/expense.dart';

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,13 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod/flutter_'
-    'r'
-    'ive'
-    'r'
-    'pod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:payment_calendar/main.dart';
 import 'package:payment_calendar/providers/settings_provider.dart';


### PR DESCRIPTION
## Summary
- replace all split flutter_riverpod imports with the standard package URI so the analyzer can resolve the dependency

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d35731f8e88332956dad33942667fc