### PR TITLE
Add equatable dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   uuid: ^3.0.7
   image_picker: ^1.0.4
   path_provider: ^2.0.12
+  equatable: ^2.0.7
   flutter_local_notifications: ^17.2.1
   timezone: ^0.9.2
   multi_dropdown:


### PR DESCRIPTION
## Summary
- add the equatable package to the app's dependencies

## Testing
- flutter pub get (fails: command not found: flutter)

------
https://chatgpt.com/codex/tasks/task_e_68d388685a308332ab9b253d141f8a99