### PR TITLE
Set navy scaffold background

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,7 +32,8 @@ class PaymentCalendarApp extends ConsumerWidget {
       title: 'Payment Calendar',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF001F3F)),
+        scaffoldBackgroundColor: const Color(0xFF001F3F),
         useMaterial3: true,
         fontFamily: 'N'
             'o'


### PR DESCRIPTION
## Summary
- update the app theme to use a navy seed color
- apply the same navy tone to the scaffold background for consistent styling

## Testing
- `flutter test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6aa9fa51483329bf6fb73c929a0d4