### PR TITLE
Adjust app theme base color to #3366CC

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,8 +32,8 @@ class PaymentCalendarApp extends ConsumerWidget {
       title: 'Payment Calendar',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF001F3F)),
-        scaffoldBackgroundColor: const Color(0xFF001F3F),
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF3366CC)),
+        scaffoldBackgroundColor: const Color(0xFF3366CC),
         useMaterial3: true,
         fontFamily: 'N'
             'o'


### PR DESCRIPTION
## Summary
- update the global theme seed and scaffold background colors to use #3366CC so the app background reflects the new brand color

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7acaab8c883329461e24d22c889ac