### PR TITLE
Adjust app background color

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,8 +32,12 @@ class PaymentCalendarApp extends ConsumerWidget {
       title: 'Payment Calendar',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF3366CC)),
-        scaffoldBackgroundColor: const Color(0xFF3366CC),
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF3366CC))
+            .copyWith(
+          background: const Color(0xFFFFFAF0),
+          surface: const Color(0xFFFFFAF0),
+        ),
+        scaffoldBackgroundColor: const Color(0xFFFFFAF0),
         useMaterial3: true,
         fontFamily: 'N'
             'o'


### PR DESCRIPTION
## Summary
- update the global theme to use a floral white (#FFFAF0) background for scaffolds and surfaces

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7b7dd5734833285f534eebcfc68b4