### PR TITLE
Set person summary card background to white

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -160,6 +160,7 @@ class _PersonSummaryTile extends ConsumerWidget {
 
     return Card(
       elevation: 2,
+      color: const Color(0xFFFFFFFF),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
         padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## Summary
- set the person summary cards on the home screen to use a white background for clarity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7c21895f4833285ff23372b3e07c9