### PR TITLE
Adjust person summary card shadow

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -159,7 +159,8 @@ class _PersonSummaryTile extends ConsumerWidget {
     final colorScheme = Theme.of(context).colorScheme;
 
     return Card(
-      elevation: 2,
+      elevation: 4,
+      shadowColor: const Color.fromRGBO(0, 0, 0, 0.05),
       color: const Color(0xFFFFFFFF),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(


### PR DESCRIPTION
## Summary
- update the person summary card to use a softer rgba(0,0,0,0.05) shadow
- increase the card elevation to match the requested 4px shadow depth

## Testing
- Not run (Flutter CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7c401585083329fcd4a4f47df4942