### PR TITLE
Align pay-all button layout with person detail button

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -260,13 +260,13 @@ class _PersonSummaryTile extends ConsumerWidget {
                 ),
                 const SizedBox(width: 12),
                 Expanded(
-                  child: ElevatedButton.icon(
+                  child: OutlinedButton.icon(
                     onPressed: hasPayTargets
                         ? () => _onPayAllPressed(context, ref)
                         : null,
                     icon: const Icon(Icons.payment, size: 18),
                     label: const Text('全件支払い'),
-                    style: ElevatedButton.styleFrom(
+                    style: OutlinedButton.styleFrom(
                       padding: const EdgeInsets.symmetric(vertical: 12),
                     ),
                   ),


### PR DESCRIPTION
## Summary
- update the pay-all button in the person summary card to use an outlined layout matching the person detail button

## Testing
- flutter test *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c69c72bc83329754965cb20204ec