### PR TITLE
Adjust unpaid screen background color

### DIFF
--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -69,7 +69,7 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
         filteredExpenses.fold<int>(0, (sum, expense) => sum + expense.amount);
 
     return Scaffold(
-      backgroundColor: Colors.grey[50],
+      backgroundColor: const Color(0xFFFFFAF0),
       appBar: AppBar(
         title: const Text('未払い一覧'),
         backgroundColor: Colors.white,


### PR DESCRIPTION
## Summary
- update the unpaid list screen scaffold background color to #FFFAF0 to match the requested palette

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7c8cb5c9483328ffc552017a4b263