### PR TITLE
Ensure settings screen list items use white background

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -163,6 +163,7 @@ class _SettingsSection extends StatelessWidget {
         ),
         Card(
           margin: const EdgeInsets.symmetric(horizontal: 16),
+          color: Colors.white,
           child: Column(children: children),
         ),
       ],


### PR DESCRIPTION
## Summary
- set the settings section card background color to white so list items appear as #FFFFFF

## Testing
- bash: command not found: flutter

------
https://chatgpt.com/codex/tasks/task_e_68d7ca49db248332bdabaaaeddccb48b