### PR TITLE
Adjust unpaid list item background color

### DIFF
--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -584,6 +584,7 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
       margin: const EdgeInsets.only(bottom: 12),
       elevation: 1,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      color: const Color(0xFFFFFFFF),
       child: ListTile(
         contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         leading: Checkbox(


### PR DESCRIPTION
## Summary
- set unpaid screen list cards to use a white background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7cb70aec48332aa9d4023bcee9859