### PR TITLE
Adjust unpaid summary bar background

### DIFF
--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -153,7 +153,7 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
         ],
       ),
       bottomNavigationBar: Container(
-        color: Colors.white,
+        color: const Color(0xFFFFFAF0),
         padding: const EdgeInsets.all(16),
         child: SafeArea(
           child: Text(


### PR DESCRIPTION
## Summary
- update the unpaid list screen's summary footer to use the #FFFAF0 background color to match the screen theme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7d9b002b08332b9c18a86bbb82979