### PR TITLE
Update personal detail screen background color

### DIFF
--- a/lib/screens/person/person_detail_screen.dart
+++ b/lib/screens/person/person_detail_screen.dart
@@ -65,7 +65,7 @@ class _PersonDetailScreenState
         : (currentTotal > 0 ? Colors.red[600] : Colors.grey[600]);
 
     return Scaffold(
-      backgroundColor: Colors.grey[50],
+      backgroundColor: const Color(0xFFFFFAF0),
       appBar: AppBar(
         backgroundColor: Colors.white,
         foregroundColor: Colors.black87,


### PR DESCRIPTION
## Summary
- set the personal detail screen scaffold background to #FFFAF0 to match the requested design

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d897cec51c8332ad0612066f4d6763