### PR TITLE
Set unpaid list item background to white

### DIFF
--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -587,6 +587,7 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
       color: const Color(0xFFFFFFFF),
       child: ListTile(
         contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        tileColor: const Color(0xFFFFFFFF),
         leading: Checkbox(
           value: false,
           onChanged: (_) => _markExpenseAsPaid(expense),


### PR DESCRIPTION
## Summary
- ensure unpaid list tiles use a pure white background to match the requested styling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d899f9cba483329c2c39bf51453b54