### PR TITLE
Remove unpaid list button from home cards

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -196,36 +196,24 @@ class _PersonSummaryTile extends ConsumerWidget {
                     ],
                   ),
                 ),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: [
-                    IconButton(
-                      tooltip: '未払い一覧を開く',
-                      onPressed: () {
-                        Navigator.of(context).push(
-                          MaterialPageRoute(
-                            builder: (_) => UnpaidScreen(
-                              initialPersonId: summary.person.id,
-                            ),
-                          ),
-                        );
-                      },
-                      icon: const Icon(Icons.chevron_right),
-                    ),
-                    if (summary.unpaidCount > 0)
-                      _CountBadge(
-                        text: '未払い${summary.unpaidCount}件',
-                        color: colorScheme.error,
-                      ),
-                    if (hasPlanned) ...[
-                      const SizedBox(height: 4),
-                      _CountBadge(
-                        text: '予定${summary.plannedCount}件',
-                        color: colorScheme.secondary,
-                      ),
+                if (summary.unpaidCount > 0 || hasPlanned)
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      if (summary.unpaidCount > 0)
+                        _CountBadge(
+                          text: '未払い${summary.unpaidCount}件',
+                          color: colorScheme.error,
+                        ),
+                      if (hasPlanned) ...[
+                        const SizedBox(height: 4),
+                        _CountBadge(
+                          text: '予定${summary.plannedCount}件',
+                          color: colorScheme.secondary,
+                        ),
+                      ],
                     ],
-                  ],
-                ),
+                  ),
               ],
             ),
             const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- remove the "未払い一覧を開く" icon button from each home screen summary card
- keep the unpaid and planned count badges visible when present

## Testing
- not run (flutter tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d89bca8aa8833280e4cf3427f77af7