### PR TITLE
Set person detail list item background to white

### DIFF
--- a/lib/screens/person/person_detail_screen.dart
+++ b/lib/screens/person/person_detail_screen.dart
@@ -405,6 +405,7 @@ class _PersonDetailScreenState
       margin: const EdgeInsets.only(bottom: 12),
       elevation: 1,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      color: const Color(0xFFFFFFFF),
       child: ListTile(
         contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         leading: isPaid


### PR DESCRIPTION
## Summary
- ensure person detail expense cards render with a white background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89d54f4c48332a7d26ea7278c9eca