### PR TITLE
Update navigation bars to brand blue

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -30,8 +30,8 @@ class HomeScreen extends ConsumerWidget {
       backgroundColor: colorScheme.surface.withOpacityValue(0.3),
       appBar: AppBar(
         title: const Text('ホーム'),
-        backgroundColor: colorScheme.surface,
-        foregroundColor: colorScheme.onSurface,
+        backgroundColor: const Color(0xFF3366FF),
+        foregroundColor: Colors.white,
         elevation: 0,
         actions: [
           IconButton(

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -18,8 +18,8 @@ class SettingsScreen extends ConsumerWidget {
       appBar: AppBar(
         title: const Text('設定'),
         elevation: 0,
-        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-        foregroundColor: Theme.of(context).colorScheme.onSurface,
+        backgroundColor: const Color(0xFF3366FF),
+        foregroundColor: Colors.white,
       ),
       body: ListView(
         padding: EdgeInsets.zero,

--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -72,8 +72,8 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
       backgroundColor: const Color(0xFFFFFAF0),
       appBar: AppBar(
         title: const Text('未払い一覧'),
-        backgroundColor: Colors.white,
-        foregroundColor: Colors.black87,
+        backgroundColor: const Color(0xFF3366FF),
+        foregroundColor: Colors.white,
         elevation: 0,
       ),
       body: Column(


### PR DESCRIPTION
## Summary
- update the Home, Unpaid, and Settings screen app bars to use the #3366FF brand color
- set the corresponding foreground colors to white for consistent readability

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8bc775a088332a27343bd7ab70786