### PR TITLE
Add photo picker to person management

### DIFF
--- a/lib/models/person.dart
+++ b/lib/models/person.dart
@@ -13,16 +13,20 @@ class Person {
 
   Person copyWith({
     String? name,
-    String? photoPath,
-    String? emoji,
+    Object? photoPath = _noValue,
+    Object? emoji = _noValue,
   }) {
     return Person(
       id: id,
       name: name ?? this.name,
-      photoPath: photoPath ?? this.photoPath,
-      emoji: emoji ?? this.emoji,
+      photoPath: identical(photoPath, _noValue)
+          ? this.photoPath
+          : photoPath as String?,
+      emoji: identical(emoji, _noValue) ? this.emoji : emoji as String?,
     );
   }
+
+  static const Object _noValue = Object();
 
   @override
   bool operator ==(Object other) {


### PR DESCRIPTION
## Summary
- allow adding or editing people with either an emoji or a selected/captured photo
- persist and display person photos within the management list view
- update the person model helper to support clearing or replacing stored photos

## Testing
- not run (flutter tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8bf6e5fa483329753054abd903086