### PR TITLE
Make home add button icon white

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -100,7 +100,10 @@ class HomeScreen extends ConsumerWidget {
             builder: (_) => const ExpenseFormSheet(),
           );
         },
-        child: const Icon(Icons.add),
+        child: const Icon(
+          Icons.add,
+          color: Colors.white,
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- update the home screen floating action button so the add icon renders in white for better contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8de0000148332b38f2cda8c05aa27