### PR TITLE
Adjust settings section title color

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -159,7 +159,7 @@ class _SettingsSection extends StatelessWidget {
                 title,
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
                       fontWeight: FontWeight.w600,
-                      color: Theme.of(context).colorScheme.primary,
+                      color: const Color(0xFF9E9E9E),
                     ),
               ),
             ],


### PR DESCRIPTION
## Summary
- update the settings section header text color to #9E9E9E to match the requested styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8e385afe4833291cee63aec6804eb