### PR TITLE
Adjust button text color to match design

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -247,6 +247,7 @@ class _PersonSummaryTile extends ConsumerWidget {
                     label: const Text('個人詳細'),
                     style: OutlinedButton.styleFrom(
                       padding: const EdgeInsets.symmetric(vertical: 12),
+                      foregroundColor: const Color(0xFF3366CC),
                     ),
                   ),
                 ),
@@ -260,6 +261,7 @@ class _PersonSummaryTile extends ConsumerWidget {
                     label: const Text('全件支払い'),
                     style: OutlinedButton.styleFrom(
                       padding: const EdgeInsets.symmetric(vertical: 12),
+                      foregroundColor: const Color(0xFF3366CC),
                     ),
                   ),
                 ),


### PR DESCRIPTION
## Summary
- update the Home screen action buttons for 個人詳細 and 全件支払い to use the specified #3366CC foreground color

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8f0bbc24083328b5828618695b1db