### PR TITLE
Set expense record form background color

### DIFF
--- a/lib/screens/expense/expense_form_sheet.dart
+++ b/lib/screens/expense/expense_form_sheet.dart
@@ -77,32 +77,35 @@ class _ExpenseFormSheetState extends ConsumerState<ExpenseFormSheet> {
       _personId = people.first.id;
     }
 
-    return Padding(
-      padding: EdgeInsets.only(
-        bottom: MediaQuery.of(context).viewInsets.bottom,
-      ),
-      child: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16),
-          child: Form(
-            key: _formKey,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _buildHeader(context),
-                const SizedBox(height: 24),
-                _buildDateSection(context),
-                const SizedBox(height: 24),
-                _buildPersonSection(context, people),
-                const SizedBox(height: 24),
-                _buildAmountSection(context),
-                const SizedBox(height: 24),
-                _buildMemoSection(context),
-                const SizedBox(height: 24),
-                _buildPhotoSection(context),
-                const SizedBox(height: 32),
-                _buildActions(context),
-              ],
+    return Container(
+      color: const Color(0xFFFFFAF0),
+      child: Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: SafeArea(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildHeader(context),
+                  const SizedBox(height: 24),
+                  _buildDateSection(context),
+                  const SizedBox(height: 24),
+                  _buildPersonSection(context, people),
+                  const SizedBox(height: 24),
+                  _buildAmountSection(context),
+                  const SizedBox(height: 24),
+                  _buildMemoSection(context),
+                  const SizedBox(height: 24),
+                  _buildPhotoSection(context),
+                  const SizedBox(height: 32),
+                  _buildActions(context),
+                ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
## Summary
- wrap the expense form sheet content in a container with a floral white background to update the record addition screen appearance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d92dabec0083329c40a00a305cfb14