### PR TITLE
Remove calendar icon from record creation date field

### DIFF
--- a/lib/screens/expense/expense_form_sheet.dart
+++ b/lib/screens/expense/expense_form_sheet.dart
@@ -153,8 +153,6 @@ class _ExpenseFormSheetState extends ConsumerState<ExpenseFormSheet> {
             ),
             child: Row(
               children: [
-                Icon(Icons.calendar_today, color: theme.colorScheme.primary),
-                const SizedBox(width: 12),
                 Expanded(
                   child: Text(
                     formatDate(_selectedDate),


### PR DESCRIPTION
## Summary
- remove the calendar icon from the date row in the expense form sheet so only the selected date is shown

## Testing
- not run (flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9303db7548332ac21dfd5bc9d64f4