### PR TITLE
Adjust cancel button styling for record add screen

### DIFF
--- a/lib/screens/expense/expense_form_sheet.dart
+++ b/lib/screens/expense/expense_form_sheet.dart
@@ -588,6 +588,9 @@ class _ExpenseFormSheetState extends ConsumerState<ExpenseFormSheet> {
         Expanded(
           child: OutlinedButton(
             onPressed: _saving ? null : () => Navigator.of(context).pop(),
+            style: OutlinedButton.styleFrom(
+              backgroundColor: Colors.white,
+            ),
             child: const Text('キャンセル'),
           ),
         ),


### PR DESCRIPTION
## Summary
- set the cancel button on the expense creation sheet to use a white background to match the design

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d934e96f088332876aebae6298164b