### PR TITLE
Set home card action text to black

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -247,7 +247,7 @@ class _PersonSummaryTile extends ConsumerWidget {
                     label: const Text('個人詳細'),
                     style: OutlinedButton.styleFrom(
                       padding: const EdgeInsets.symmetric(vertical: 12),
-                      foregroundColor: const Color(0xFF3366CC),
+                      foregroundColor: Colors.black,
                     ),
                   ),
                 ),
@@ -261,7 +261,7 @@ class _PersonSummaryTile extends ConsumerWidget {
                     label: const Text('全件支払い'),
                     style: OutlinedButton.styleFrom(
                       padding: const EdgeInsets.symmetric(vertical: 12),
-                      foregroundColor: const Color(0xFF3366CC),
+                      foregroundColor: Colors.black,
                     ),
                   ),
                 ),


### PR DESCRIPTION
## Summary
- update the home screen person cards so the "個人詳細" and "全件支払い" actions use black text for their labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d93627b5808332872e0789fcc502f2