### PR TITLE
Remove calendar icon from planned toggle on home screen

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -52,8 +52,6 @@ class HomeScreen extends ConsumerWidget {
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
             child: Row(
               children: [
-                Icon(Icons.event, color: colorScheme.primary),
-                const SizedBox(width: 8),
                 Text(
                   '予定を含める',
                   style: Theme.of(context)


### PR DESCRIPTION
## Summary
- remove the calendar icon from the "予定を含める" toggle on the home screen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9372a400c8332a60170cb64de7d00