### PR TITLE
Adjust cancel button styling on expense form

### DIFF
--- a/lib/screens/expense/expense_form_sheet.dart
+++ b/lib/screens/expense/expense_form_sheet.dart
@@ -586,9 +586,9 @@ class _ExpenseFormSheetState extends ConsumerState<ExpenseFormSheet> {
     return Row(
       children: [
         Expanded(
-          child: OutlinedButton(
+          child: ElevatedButton(
             onPressed: _saving ? null : () => Navigator.of(context).pop(),
-            style: OutlinedButton.styleFrom(
+            style: ElevatedButton.styleFrom(
               backgroundColor: Colors.white,
             ),
             child: const Text('キャンセル'),


### PR DESCRIPTION
## Summary
- update the expense form cancel button to use the same elevated style as the save button
- remove the dark outline and ensure the cancel action shares the save button's shadow treatment

## Testing
- flutter test *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d938302dd48332a6bc395a9d7122b2