### PR TITLE
Set selected person background to white

### DIFF
--- a/lib/screens/expense/expense_form_sheet.dart
+++ b/lib/screens/expense/expense_form_sheet.dart
@@ -221,9 +221,7 @@ class _ExpenseFormSheetState extends ConsumerState<ExpenseFormSheet> {
             color: isSelected ? theme.colorScheme.primary : theme.dividerColor,
             width: 2,
           ),
-            color: isSelected
-                ? theme.colorScheme.primaryContainer.withOpacityValue(0.4)
-                : theme.colorScheme.surface,
+          color: isSelected ? Colors.white : theme.colorScheme.surface,
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## Summary
- set the selected person option in the expense form to use a white background for clarity

## Testing
- flutter test *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d93c3e3fe483328918efb2bd7621df