### PR TITLE
Adjust unpaid screen header background color

### DIFF
--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -79,7 +79,7 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
       body: Column(
         children: [
           Container(
-            color: Colors.white,
+            color: const Color(0xFFFFFAF0),
             padding: const EdgeInsets.all(16),
             child: Column(
               children: [


### PR DESCRIPTION
## Summary
- update the unpaid list header container to use the #FFFAF0 background color so it matches the screen theme

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d93ec99c8c8332ba0e1b014902a367