### PR TITLE
Adjust switch active color

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -62,6 +62,7 @@ class HomeScreen extends ConsumerWidget {
                 const Spacer(),
                 Switch(
                   value: includePlanned,
+                  activeColor: const Color(0xFF3366FF),
                   onChanged: (value) => ref
                       .read(includePlannedInSummaryProvider.notifier)
                       .state = value,

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -190,6 +190,7 @@ class _SettingsSwitchTile extends StatelessWidget {
         ),
       ),
       value: enabled ? value : false,
+      activeColor: const Color(0xFF3366FF),
       onChanged: enabled ? onChanged : null,
       secondary: icon == null
           ? null


### PR DESCRIPTION
## Summary
- set the summary screen switch active color to #3366FF
- apply the same #3366FF active color to settings switches

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d9414b6cc4833286e24071dc2ad86c