### PR TITLE
Replace default pet character with child

### DIFF
--- a/lib/providers/expense_provider.dart
+++ b/lib/providers/expense_provider.dart
@@ -11,7 +11,7 @@ class ExpenseProvider extends ChangeNotifier {
   final List<Person> members = const [
     Person(id: 'mother', name: '母', emoji: '👩'),
     Person(id: 'father', name: '父', emoji: '👨'),
-    Person(id: 'pet', name: 'キャラ', emoji: '🐱'),
+    Person(id: 'child', name: '子ども', emoji: '🧒'),
   ];
 
   List<Expense> get expenses => List.unmodifiable(_expenses);

--- a/lib/providers/expenses_provider.dart
+++ b/lib/providers/expenses_provider.dart
@@ -32,10 +32,10 @@ class ExpensesNotifier extends StateNotifier<List<Expense>> {
       ),
       Expense.newRecord(
         id: uuid.v4(),
-        personId: 'pet',
+        personId: 'child',
         date: now,
         amount: 2400,
-        memo: 'キャットフードまとめ買い',
+        memo: '子どもの服',
       ),
       Expense.newRecord(
         id: uuid.v4(),

--- a/lib/providers/people_provider.dart
+++ b/lib/providers/people_provider.dart
@@ -12,7 +12,7 @@ class PeopleNotifier extends StateNotifier<List<Person>> {
       : super(const [
           Person(id: 'mother', name: '母', emoji: '👩'),
           Person(id: 'father', name: '父', emoji: '👨'),
-          Person(id: 'pet', name: 'キャラ', emoji: '🐱'),
+          Person(id: 'child', name: '子ども', emoji: '🧒'),
         ]);
 
   final _uuid = const Uuid();


### PR DESCRIPTION
## Summary
- update the default household member list to use a child character instead of the pet
- refresh the seeded expense to align with the new child character details

## Testing
- `flutter test` *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d95dca750c833296b096843a77e1b4