### PR TITLE
Adjust switch thumb color when active

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -62,7 +62,8 @@ class HomeScreen extends ConsumerWidget {
                 const Spacer(),
                 Switch(
                   value: includePlanned,
-                  activeColor: const Color(0xFF3366FF),
+                  activeColor: Colors.white,
+                  activeTrackColor: const Color(0xFF3366FF),
                   onChanged: (value) => ref
                       .read(includePlannedInSummaryProvider.notifier)
                       .state = value,

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -190,7 +190,8 @@ class _SettingsSwitchTile extends StatelessWidget {
         ),
       ),
       value: enabled ? value : false,
-      activeColor: const Color(0xFF3366FF),
+      activeColor: Colors.white,
+      activeTrackColor: const Color(0xFF3366FF),
       onChanged: enabled ? onChanged : null,
       secondary: icon == null
           ? null


### PR DESCRIPTION
## Summary
- set the active switch thumb color to white on the home include-planned switch while keeping the track blue
- update settings switches to use a white active thumb and retain the existing blue track color

## Testing
- flutter test *(fails: flutter command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d95f8d9ee08332af30db116170ca9d