### PR TITLE
Update settings list icon color to #3366FF

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -10,6 +10,8 @@ import '../../models/person.dart';
 import '../../providers/people_provider.dart';
 import '../../providers/settings_provider.dart';
 
+const _settingsIconColor = Color(0xFF3366FF);
+
 class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
 
@@ -197,9 +199,7 @@ class _SettingsSwitchTile extends StatelessWidget {
           ? null
           : Icon(
               icon,
-              color: enabled
-                  ? Theme.of(context).colorScheme.primary
-                  : Colors.grey.shade400,
+              color: enabled ? _settingsIconColor : Colors.grey.shade400,
             ),
     );
 
@@ -232,7 +232,7 @@ class _SettingsListTile extends StatelessWidget {
       ),
       leading: leadingIcon == null
           ? null
-          : Icon(leadingIcon, color: Theme.of(context).colorScheme.primary),
+          : Icon(leadingIcon, color: _settingsIconColor),
       trailing: Icon(trailingIcon, color: Colors.grey.shade600),
       onTap: onTap,
     );


### PR DESCRIPTION
## Summary
- add a shared constant for the settings icon color
- update settings list and switch tiles to use the new #3366FF icon color when enabled

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d96193417c83328b0cb8a8afb052cf