### PR TITLE
Set person management list cards to white background

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -397,6 +397,7 @@ class _PersonManagementScreenState
                 return Card(
                   margin:
                       const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                  color: Colors.white,
                   child: ListTile(
                     leading: _buildAvatar(person),
                     title: Text(


### PR DESCRIPTION
## Summary
- set the person management list cards to use a white background color

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d962c8715483328e9ce47c6bccfb8f