### PR TITLE
Set people add button to white background

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -455,6 +455,8 @@ class _PersonManagementScreenState
         onPressed: _addPerson,
         icon: const Icon(Icons.person_add),
         label: const Text('人を追加'),
+        backgroundColor: Colors.white,
+        foregroundColor: Theme.of(context).colorScheme.primary,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- set the human management "add person" floating action button to a white background with primary-colored text and icon for better contrast

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9641cf42883328a923a4a3b481d43