### PR TITLE
Adjust switch inactive color

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -64,6 +64,7 @@ class HomeScreen extends ConsumerWidget {
                   value: includePlanned,
                   activeColor: Colors.white,
                   activeTrackColor: const Color(0xFF3366FF),
+                  inactiveTrackColor: const Color(0xFFCCCCCC),
                   onChanged: (value) => ref
                       .read(includePlannedInSummaryProvider.notifier)
                       .state = value,

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -194,6 +194,7 @@ class _SettingsSwitchTile extends StatelessWidget {
       value: enabled ? value : false,
       activeColor: Colors.white,
       activeTrackColor: const Color(0xFF3366FF),
+      inactiveTrackColor: const Color(0xFFCCCCCC),
       onChanged: enabled ? onChanged : null,
       secondary: icon == null
           ? null


### PR DESCRIPTION
## Summary
- set the home screen summary switch inactive track color to #CCCCCC
- update settings switches to use #CCCCCC when turned off for consistent styling

## Testing
- flutter test *(fails: flutter is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9667bde7c83329aef64202f9fc643