### PR TITLE
Add illustrated avatars for default family members

### DIFF
--- a/lib/screens/expense/expense_detail_screen.dart
+++ b/lib/screens/expense/expense_detail_screen.dart
@@ -9,6 +9,7 @@ import '../../providers/expenses_provider.dart';
 import '../../providers/people_provider.dart';
 import '../../utils/color_utils.dart';
 import '../../utils/date_util.dart';
+import '../../widgets/person_avatar.dart';
 import 'expense_form_sheet.dart';
 
 class ExpenseDetailScreen extends ConsumerWidget {
@@ -94,25 +95,14 @@ class ExpenseDetailScreen extends ConsumerWidget {
   }
 
   Widget _buildAvatar(Person person) {
-    const radius = 28.0;
-    final photoPath = person.photoPath;
-    if (photoPath != null && photoPath.isNotEmpty) {
-      final file = File(photoPath);
-      if (file.existsSync()) {
-        return CircleAvatar(
-          radius: radius,
-          backgroundImage: FileImage(file),
-        );
-      }
-    }
-
-    final display = person.emoji ??
-        (person.name.characters.isNotEmpty ? person.name.characters.first : '?');
-    return CircleAvatar(
-      radius: radius,
-      child: Text(
-        display,
-        style: const TextStyle(fontSize: 28, fontWeight: FontWeight.bold),
+    const double size = 56;
+    return PersonAvatar(
+      person: person,
+      size: size,
+      backgroundColor: Colors.grey.shade200,
+      textStyle: const TextStyle(
+        fontSize: 28,
+        fontWeight: FontWeight.bold,
       ),
     );
   }

--- a/lib/screens/expense/expense_form_sheet.dart
+++ b/lib/screens/expense/expense_form_sheet.dart
@@ -10,6 +10,7 @@ import '../../models/person.dart';
 import '../../providers/expenses_provider.dart';
 import '../../providers/people_provider.dart';
 import '../../utils/date_util.dart';
+import '../../widgets/person_avatar.dart';
 
 class ExpenseFormSheet extends ConsumerStatefulWidget {
   const ExpenseFormSheet({super.key, this.expenseId});
@@ -414,48 +415,15 @@ class _ExpenseFormSheetState extends ConsumerState<ExpenseFormSheet> {
 
   Widget _buildPersonAvatar(Person person, {double size = 56}) {
     final theme = Theme.of(context);
-    final photoPath = person.photoPath;
-    if (photoPath != null && File(photoPath).existsSync()) {
-      return Container(
-        width: size,
-        height: size,
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-              boxShadow: [
-                BoxShadow(
-                  color: Colors.black.withOpacityValue(0.1),
-              blurRadius: 4,
-              offset: const Offset(0, 2),
-            ),
-          ],
-        ),
-        clipBehavior: Clip.antiAlias,
-        child: Image.file(
-          File(photoPath),
-          fit: BoxFit.cover,
-        ),
-      );
-    }
-    final emoji = person.emoji;
-    final text = emoji?.isNotEmpty == true
-        ? emoji!
-        : person.name.characters.isNotEmpty
-            ? person.name.characters.first
-            : '?';
-    return Container(
-      width: size,
-      height: size,
-      decoration: BoxDecoration(
-        color: theme.colorScheme.primaryContainer,
-        shape: BoxShape.circle,
-      ),
-      alignment: Alignment.center,
-      child: Text(
-        text,
-        style: TextStyle(
-          fontSize: size * 0.45,
-          fontWeight: FontWeight.bold,
-        ),
+    return PersonAvatar(
+      person: person,
+      size: size,
+      showShadow: true,
+      backgroundColor: theme.colorScheme.primaryContainer,
+      textStyle: TextStyle(
+        fontSize: size * 0.45,
+        fontWeight: FontWeight.bold,
+        color: theme.colorScheme.onPrimaryContainer,
       ),
     );
   }

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:payment_calendar/utils/color_utils.dart';
@@ -14,6 +12,7 @@ import '../../screens/unpaid/unpaid_screen.dart';
 import '../../utils/date_util.dart';
 import '../expense/expense_form_sheet.dart';
 import '../settings/settings_screen.dart';
+import '../../widgets/person_avatar.dart';
 
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
@@ -363,47 +362,15 @@ class _Avatar extends StatelessWidget {
   Widget build(BuildContext context) {
     const double size = 56;
     final colorScheme = Theme.of(context).colorScheme;
-    final photoPath = summary.person.photoPath;
-    if (photoPath != null && File(photoPath).existsSync()) {
-      return Container(
-        width: size,
-        height: size,
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withOpacityValue(0.1),
-              blurRadius: 6,
-              offset: const Offset(0, 3),
-            ),
-          ],
-        ),
-        clipBehavior: Clip.antiAlias,
-        child: Image.file(
-          File(photoPath),
-          fit: BoxFit.cover,
-        ),
-      );
-    }
-    final emoji = summary.person.emoji;
-    final text = emoji ??
-        (summary.person.name.characters.isNotEmpty
-            ? summary.person.name.characters.first
-            : '?');
-    return Container(
-      width: size,
-      height: size,
-      decoration: BoxDecoration(
-        color: colorScheme.primaryContainer,
-        shape: BoxShape.circle,
-      ),
-      alignment: Alignment.center,
-      child: Text(
-        text,
-        style: const TextStyle(
-          fontSize: 24,
-          fontWeight: FontWeight.bold,
-        ),
+    return PersonAvatar(
+      person: summary.person,
+      size: size,
+      showShadow: true,
+      backgroundColor: colorScheme.primaryContainer,
+      textStyle: TextStyle(
+        fontSize: 24,
+        fontWeight: FontWeight.bold,
+        color: colorScheme.onPrimaryContainer,
       ),
     );
   }

--- a/lib/screens/person/person_detail_screen.dart
+++ b/lib/screens/person/person_detail_screen.dart
@@ -7,6 +7,7 @@ import '../../models/person.dart';
 import '../../providers/expenses_provider.dart';
 import '../../utils/date_util.dart';
 import '../expense/expense_detail_screen.dart';
+import '../../widgets/person_avatar.dart';
 
 enum _DateFilter { all, thisMonth, lastMonth, custom }
 
@@ -360,36 +361,14 @@ class _PersonDetailScreenState
   }
 
   Widget _buildAvatar(Person person, {double size = 32}) {
-    final radius = size / 2;
-    final placeholder = person.emoji?.isNotEmpty == true
-        ? person.emoji!
-        : (person.name.isNotEmpty ? person.name.substring(0, 1) : '?');
-    if (person.photoPath != null && person.photoPath!.isNotEmpty) {
-      return CircleAvatar(
-        radius: radius,
-        backgroundColor: Colors.grey[200],
-        child: ClipOval(
-          child: Image.asset(
-            person.photoPath!,
-            width: size,
-            height: size,
-            fit: BoxFit.cover,
-            errorBuilder: (_, __, ___) => Center(
-              child: Text(
-                placeholder,
-                style: const TextStyle(fontWeight: FontWeight.bold),
-              ),
-            ),
-          ),
-        ),
-      );
-    }
-    return CircleAvatar(
-      radius: radius,
-      backgroundColor: Colors.grey[200],
-      child: Text(
-        placeholder,
-        style: const TextStyle(fontWeight: FontWeight.bold),
+    return PersonAvatar(
+      person: person,
+      size: size,
+      backgroundColor: Colors.grey.shade200,
+      textStyle: TextStyle(
+        fontWeight: FontWeight.bold,
+        fontSize: size * 0.45,
+        color: Colors.grey.shade800,
       ),
     );
   }

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -9,6 +9,7 @@ import 'package:path_provider/path_provider.dart';
 import '../../models/person.dart';
 import '../../providers/people_provider.dart';
 import '../../providers/settings_provider.dart';
+import '../../widgets/person_avatar.dart';
 
 const _settingsIconColor = Color(0xFF3366FF);
 
@@ -333,20 +334,15 @@ class _PersonManagementScreenState
   }
 
   Widget _buildAvatar(Person person) {
-    final photoPath = person.photoPath;
-    if (photoPath != null && photoPath.isNotEmpty) {
-      final file = File(photoPath);
-      if (file.existsSync()) {
-        return CircleAvatar(backgroundImage: FileImage(file));
-      }
-    }
-    if (person.emoji != null && person.emoji!.isNotEmpty) {
-      return CircleAvatar(child: Text(person.emoji!));
-    }
-    final display = person.name.characters.isNotEmpty
-        ? person.name.characters.first
-        : _emptyEmojiPlaceholder;
-    return CircleAvatar(child: Text(display));
+    return PersonAvatar(
+      person: person,
+      size: 40,
+      backgroundColor: Colors.grey.shade200,
+      textStyle: const TextStyle(
+        fontSize: 20,
+        fontWeight: FontWeight.bold,
+      ),
+    );
   }
 
   @override

--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:payment_calendar/widgets/radio_option_tile.dart';
@@ -10,6 +8,7 @@ import '../../providers/expenses_provider.dart';
 import '../../providers/people_provider.dart';
 import '../../utils/date_util.dart';
 import '../expense/expense_detail_screen.dart';
+import '../../widgets/person_avatar.dart';
 
 class UnpaidScreen extends ConsumerStatefulWidget {
   const UnpaidScreen({super.key, this.initialPersonId});
@@ -692,32 +691,19 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
   }
 
   Widget _buildSmallAvatar(Person? person) {
-    const double radius = 16;
+    const double size = 32;
     if (person == null) {
       return const CircleAvatar(
-        radius: radius,
+        radius: size / 2,
         child: Text('?', style: TextStyle(fontWeight: FontWeight.bold)),
       );
     }
 
-    final photoPath = person.photoPath;
-    if (photoPath != null && File(photoPath).existsSync()) {
-      return CircleAvatar(
-        radius: radius,
-        backgroundImage: FileImage(File(photoPath)),
-      );
-    }
-
-    final display = person.emoji ??
-        (person.name.characters.isNotEmpty
-            ? person.name.characters.first
-            : '?');
-    return CircleAvatar(
-      radius: radius,
-      child: Text(
-        display,
-        style: const TextStyle(fontWeight: FontWeight.bold),
-      ),
+    return PersonAvatar(
+      person: person,
+      size: size,
+      backgroundColor: Colors.grey.shade300,
+      textStyle: const TextStyle(fontWeight: FontWeight.bold),
     );
   }
 

--- a/lib/widgets/person_avatar.dart
+++ b/lib/widgets/person_avatar.dart
@@ -1,0 +1,349 @@
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+import '../models/person.dart';
+
+class PersonAvatar extends StatelessWidget {
+  const PersonAvatar({
+    super.key,
+    required this.person,
+    this.size = 32,
+    this.backgroundColor,
+    this.textStyle,
+    this.showShadow = false,
+  });
+
+  final Person person;
+  final double size;
+  final Color? backgroundColor;
+  final TextStyle? textStyle;
+  final bool showShadow;
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget content = _buildContent(context);
+
+    if (!showShadow) {
+      return content;
+    }
+
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.1),
+            blurRadius: 6,
+            offset: const Offset(0, 3),
+          ),
+        ],
+      ),
+      child: content,
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    final photoPath = person.photoPath;
+    if (photoPath != null && photoPath.isNotEmpty) {
+      final file = File(photoPath);
+      if (file.existsSync()) {
+        return SizedBox(
+          width: size,
+          height: size,
+          child: ClipOval(
+            child: Image.file(
+              file,
+              width: size,
+              height: size,
+              fit: BoxFit.cover,
+            ),
+          ),
+        );
+      }
+    }
+
+    final builtIn = _BuiltInIllustration.fromPerson(person);
+    if (builtIn != null) {
+      return builtIn.build(size);
+    }
+
+    final placeholder = person.emoji?.isNotEmpty == true
+        ? person.emoji!
+        : (person.name.characters.isNotEmpty
+            ? person.name.characters.first
+            : '?');
+
+    final Color resolvedBackground = backgroundColor ??
+        Theme.of(context).colorScheme.primaryContainer;
+    final TextStyle resolvedStyle = textStyle ??
+        TextStyle(
+          fontSize: size * 0.42,
+          fontWeight: FontWeight.bold,
+          color: Theme.of(context).colorScheme.onPrimaryContainer,
+        );
+
+    return SizedBox(
+      width: size,
+      height: size,
+      child: ClipOval(
+        child: Container(
+          color: resolvedBackground,
+          alignment: Alignment.center,
+          child: Text(placeholder, style: resolvedStyle),
+        ),
+      ),
+    );
+  }
+}
+
+enum _IllustrationType { mother, father, child }
+
+class _BuiltInIllustration {
+  _BuiltInIllustration(this.type);
+
+  final _IllustrationType type;
+
+  static _BuiltInIllustration? fromPerson(Person person) {
+    switch (person.id) {
+      case 'mother':
+        return _BuiltInIllustration(_IllustrationType.mother);
+      case 'father':
+        return _BuiltInIllustration(_IllustrationType.father);
+      case 'child':
+        return _BuiltInIllustration(_IllustrationType.child);
+    }
+    return null;
+  }
+
+  Widget build(double size) {
+    return SizedBox(
+      width: size,
+      height: size,
+      child: CustomPaint(
+        painter: _PersonIllustrationPainter(type),
+      ),
+    );
+  }
+}
+
+class _PersonIllustrationPainter extends CustomPainter {
+  _PersonIllustrationPainter(this.type);
+
+  final _IllustrationType type;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final double radius = size.width / 2;
+    final Offset center = Offset(radius, radius);
+
+    final palette = _paletteFor(type);
+
+    final Paint backgroundPaint = Paint()..color = palette.background;
+    canvas.drawCircle(center, radius, backgroundPaint);
+
+    final Rect bodyRect = Rect.fromCenter(
+      center: Offset(center.dx, size.height * 0.88),
+      width: size.width * 0.92,
+      height: size.height * 0.7,
+    );
+    final Paint bodyPaint = Paint()..color = palette.body;
+    canvas.drawOval(bodyRect, bodyPaint);
+
+    final Rect faceRect = Rect.fromCircle(
+      center: Offset(center.dx, size.height * 0.47),
+      radius: size.width * 0.28,
+    );
+    final Paint facePaint = Paint()..color = const Color(0xFFFFE2C6);
+    canvas.drawOval(faceRect, facePaint);
+
+    final Path hairPath = Path();
+    final double hairTop = size.height * 0.18;
+    hairPath.moveTo(size.width * 0.18, size.height * 0.42);
+    hairPath.quadraticBezierTo(
+      size.width * 0.24,
+      hairTop,
+      center.dx,
+      hairTop * 0.8,
+    );
+    hairPath.quadraticBezierTo(
+      size.width * 0.76,
+      hairTop,
+      size.width * 0.82,
+      size.height * 0.42,
+    );
+    hairPath.arcTo(
+      Rect.fromCircle(
+        center: Offset(center.dx, size.height * 0.46),
+        radius: size.width * 0.32,
+      ),
+      -pi,
+      pi,
+      false,
+    );
+    hairPath.close();
+    final Paint hairPaint = Paint()..color = palette.hair;
+    canvas.drawPath(hairPath, hairPaint);
+
+    if (type == _IllustrationType.father) {
+      final Paint fringePaint = Paint()..color = palette.hairDark;
+      final Path fringePath = Path()
+        ..moveTo(center.dx - size.width * 0.18, size.height * 0.34)
+        ..quadraticBezierTo(
+          center.dx,
+          size.height * 0.26,
+          center.dx + size.width * 0.18,
+          size.height * 0.34,
+        )
+        ..lineTo(center.dx + size.width * 0.12, size.height * 0.26)
+        ..quadraticBezierTo(
+          center.dx,
+          size.height * 0.24,
+          center.dx - size.width * 0.12,
+          size.height * 0.26,
+        )
+        ..close();
+      canvas.drawPath(fringePath, fringePaint);
+    }
+
+    if (type == _IllustrationType.mother) {
+      final Paint bunPaint = Paint()..color = palette.hairDark;
+      canvas.drawCircle(
+        Offset(center.dx - size.width * 0.28, size.height * 0.22),
+        size.width * 0.12,
+        bunPaint,
+      );
+      canvas.drawCircle(
+        Offset(center.dx + size.width * 0.28, size.height * 0.22),
+        size.width * 0.12,
+        bunPaint,
+      );
+    }
+
+    if (type == _IllustrationType.child) {
+      final Paint capPaint = Paint()..color = palette.hairDark;
+      final Rect capRect = Rect.fromCenter(
+        center: Offset(center.dx, size.height * 0.32),
+        width: size.width * 0.74,
+        height: size.height * 0.38,
+      );
+      canvas.drawArc(capRect, pi, pi, false, capPaint);
+      final Paint brimPaint = Paint()
+        ..color = palette.hairDark.withOpacity(0.9)
+        ..strokeWidth = size.width * 0.08
+        ..style = PaintingStyle.stroke
+        ..strokeCap = StrokeCap.round;
+      canvas.drawArc(
+        Rect.fromCenter(
+          center: Offset(center.dx, size.height * 0.37),
+          width: size.width * 0.8,
+          height: size.height * 0.44,
+        ),
+        pi,
+        pi,
+        false,
+        brimPaint,
+      );
+    }
+
+    final Paint eyePaint = Paint()
+      ..color = palette.eye
+      ..style = PaintingStyle.fill;
+    final double eyeRadius = size.width * 0.04;
+    canvas.drawCircle(
+      Offset(center.dx - size.width * 0.1, size.height * 0.46),
+      eyeRadius,
+      eyePaint,
+    );
+    canvas.drawCircle(
+      Offset(center.dx + size.width * 0.1, size.height * 0.46),
+      eyeRadius,
+      eyePaint,
+    );
+
+    final Paint smilePaint = Paint()
+      ..color = palette.smile
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = size.width * 0.05;
+    final Rect smileRect = Rect.fromCircle(
+      center: Offset(center.dx, size.height * 0.56),
+      radius: size.width * 0.18,
+    );
+    canvas.drawArc(smileRect, pi / 6, 2 * pi / 3, false, smilePaint);
+
+    final Paint cheekPaint = Paint()..color = palette.cheek;
+    final double cheekRadius = size.width * 0.05;
+    canvas.drawCircle(
+      Offset(center.dx - size.width * 0.2, size.height * 0.53),
+      cheekRadius,
+      cheekPaint,
+    );
+    canvas.drawCircle(
+      Offset(center.dx + size.width * 0.2, size.height * 0.53),
+      cheekRadius,
+      cheekPaint,
+    );
+  }
+
+  _AvatarPalette _paletteFor(_IllustrationType type) {
+    switch (type) {
+      case _IllustrationType.mother:
+        return const _AvatarPalette(
+          background: Color(0xFFFFF4E5),
+          body: Color(0xFFFFB1C1),
+          hair: Color(0xFF6B3F2B),
+          hairDark: Color(0xFF4C2A1B),
+          eye: Color(0xFF3C2716),
+          cheek: Color(0xFFFFC7D1),
+          smile: Color(0xFFE87A90),
+        );
+      case _IllustrationType.father:
+        return const _AvatarPalette(
+          background: Color(0xFFE9F2FF),
+          body: Color(0xFF7FB4FF),
+          hair: Color(0xFF2F3A4C),
+          hairDark: Color(0xFF1F2835),
+          eye: Color(0xFF222933),
+          cheek: Color(0xFFB5D4FF),
+          smile: Color(0xFF3B77CC),
+        );
+      case _IllustrationType.child:
+        return const _AvatarPalette(
+          background: Color(0xFFFFF9E7),
+          body: Color(0xFFFFD66B),
+          hair: Color(0xFF5A3B20),
+          hairDark: Color(0xFF8B4F1F),
+          eye: Color(0xFF3A2210),
+          cheek: Color(0xFFFFE0A8),
+          smile: Color(0xFFE28A40),
+        );
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}
+
+class _AvatarPalette {
+  const _AvatarPalette({
+    required this.background,
+    required this.body,
+    required this.hair,
+    required this.hairDark,
+    required this.eye,
+    required this.cheek,
+    required this.smile,
+  });
+
+  final Color background;
+  final Color body;
+  final Color hair;
+  final Color hairDark;
+  final Color eye;
+  final Color cheek;
+  final Color smile;
+}


### PR DESCRIPTION
## Summary
- create a reusable `PersonAvatar` widget that renders illustration-style defaults for the mother, father, and child members
- replace per-screen avatar logic to use the new widget so that all built-in family members share the same illustrated style

## Testing
- not run (flutter is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d967f4a978833296c6d4614a6f7e5e