### PR TITLE
Fix PersonAvatar shadow color opacity handling

### DIFF
--- a/lib/widgets/person_avatar.dart
+++ b/lib/widgets/person_avatar.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 
 import '../models/person.dart';
+import '../utils/color_utils.dart';
 
 class PersonAvatar extends StatelessWidget {
   const PersonAvatar({
@@ -35,7 +36,7 @@ class PersonAvatar extends StatelessWidget {
         shape: BoxShape.circle,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.1),
+            color: Colors.black.withOpacityValue(0.1),
             blurRadius: 6,
             offset: const Offset(0, 3),
           ),


### PR DESCRIPTION
## Summary
- import the color opacity utility extension into `PersonAvatar`
- replace the deprecated `Color.withOpacity` call with the `withOpacityValue` helper

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9f3e19b4c833298a1fd0e8c2d157a