### PR TITLE
Fix missing characters import for avatar placeholder

### DIFF
--- a/lib/widgets/person_avatar.dart
+++ b/lib/widgets/person_avatar.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:characters/characters.dart';
 
 import '../models/person.dart';
 import '../utils/color_utils.dart';


### PR DESCRIPTION
## Summary
- add the characters package import required by the PersonAvatar widget so that placeholder generation compiles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9f6c8519883328b0fd962a8774c40