### PR TITLE
Set add person button text color to black

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -451,7 +451,10 @@ class _PersonManagementScreenState
       floatingActionButton: FloatingActionButton.extended(
         onPressed: _addPerson,
         icon: const Icon(Icons.person_add),
-        label: const Text('人を追加'),
+        label: const Text(
+          '人を追加',
+          style: TextStyle(color: Colors.black),
+        ),
         backgroundColor: Colors.white,
         foregroundColor: Theme.of(context).colorScheme.primary,
       ),


### PR DESCRIPTION
## Summary
- set the "人を追加" floating action button label text color to black on the people management screen

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9faa6a6608332bd29073c9b8c231d