### PR TITLE
Set add person dialog background color

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -666,14 +666,16 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
   Widget build(BuildContext context) {
     final photoPreview = _buildPhotoPreview();
     return Dialog(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 400),
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Form(
-            key: _formKey,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
+      child: Container(
+        color: const Color(0xFFFFFAF0),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 400),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(


### PR DESCRIPTION
## Summary
- set the add person dialog background color to #FFFAF0 for consistency

## Testing
- Not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9fc842ca08332ae6d60d58380cb16