### PR TITLE
Fix mounted checks in settings screen async callbacks

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -43,7 +43,10 @@ class SettingsScreen extends ConsumerWidget {
                   await ref
                       .read(settingsProvider.notifier)
                       .toggleReminder(value);
-                  if (value && context.mounted) {
+                  if (!context.mounted) {
+                    return;
+                  }
+                  if (value) {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(
                         content: Text('リマインド通知を有効にしました'),
@@ -284,20 +287,22 @@ class _PersonManagementScreenState
       ),
     );
 
-    if (confirmed == true && mounted) {
-      ref.read(peopleProvider.notifier).removePerson(person);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('${person.name}を削除しました'),
-          action: SnackBarAction(
-            label: '元に戻す',
-            onPressed: () {
-              ref.read(peopleProvider.notifier).restorePerson(person);
-            },
-          ),
-        ),
-      );
+    if (!mounted || confirmed != true) {
+      return;
     }
+
+    ref.read(peopleProvider.notifier).removePerson(person);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('${person.name}を削除しました'),
+        action: SnackBarAction(
+          label: '元に戻す',
+          onPressed: () {
+            ref.read(peopleProvider.notifier).restorePerson(person);
+          },
+        ),
+      ),
+    );
   }
 
   Future<void> _showPersonDialog({Person? person}) async {


### PR DESCRIPTION
## Summary
- ensure the reminder toggle callback verifies the context is still mounted before showing a snackbar
- guard the person deletion flow with a mounted check before accessing the context after awaiting the dialog result

## Testing
- Not run (Flutter SDK is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9fdabff6c833291d3286e05e536f3