### PR TITLE
Fix const SizedBox child in settings screen

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -836,7 +836,7 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
                           ? const SizedBox(
                               height: 16,
                               width: 16,
-                              child: CircularProgressIndicator(strokeWidth: 2),
+                              child: const CircularProgressIndicator(strokeWidth: 2),
                             )
                           : const Text('保存'),
                     ),


### PR DESCRIPTION
## Summary
- ensure the loading indicator in the settings dialog is a const widget so it can be used inside a const SizedBox

## Testing
- not run (environment lacks Flutter SDK)


------
https://chatgpt.com/codex/tasks/task_e_68da0988f97c8332a9cecd32296b59e1