### PR TITLE
Fix progress indicator widget constants in settings screen

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -833,10 +833,10 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
                     ElevatedButton(
                       onPressed: _submitting ? null : () => _submit(),
                       child: _submitting
-                          ? const SizedBox(
+                          ? SizedBox(
                               height: 16,
                               width: 16,
-                              child: const CircularProgressIndicator(strokeWidth: 2),
+                              child: CircularProgressIndicator(strokeWidth: 2),
                             )
                           : const Text('保存'),
                     ),


### PR DESCRIPTION
## Summary
- update the settings screen submit button to use non-const widgets for the loading indicator
- avoid analyzer errors caused by const constructors not being available

## Testing
- not run (Flutter CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68da1b51b288833293181f88d6b8c30f