### PR TITLE
Show payment timestamp with time

### DIFF
--- a/lib/screens/expense/expense_detail_screen.dart
+++ b/lib/screens/expense/expense_detail_screen.dart
@@ -125,7 +125,7 @@ class ExpenseDetailScreen extends ConsumerWidget {
         const SizedBox(height: 12),
         _InfoRow(
           label: '支払い日時',
-          value: formatDate(expense.paidAt!),
+          value: formatDateTime(expense.paidAt!),
         ),
       ]);
     }

--- a/lib/utils/date_util.dart
+++ b/lib/utils/date_util.dart
@@ -2,7 +2,10 @@ import 'package:intl/intl.dart';
 
 final _currencyFormat = NumberFormat.currency(locale: 'ja_JP', symbol: '¥');
 final _dateFormat = DateFormat('yyyy/MM/dd');
+final _dateTimeFormat = DateFormat('yyyy/MM/dd HH:mm');
 
 String formatCurrency(int amount) => _currencyFormat.format(amount);
 
 String formatDate(DateTime date) => _dateFormat.format(date);
+
+String formatDateTime(DateTime date) => _dateTimeFormat.format(date);


### PR DESCRIPTION
## Summary
- add a new utility to format date and time strings with hours and minutes
- display paid timestamps with the new formatter so the detail screen shows the time component

## Testing
- Not run (Flutter SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68da23b8a6d08332a5c37964b2aa05f9