### PR TITLE
Clarify showDialog closure in settings screen

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -312,8 +312,8 @@ class _PersonManagementScreenState
       context: context,
       builder: (context) {
         return _PersonEditDialog(person: person);
-      },
-    );
+      },   // builder を閉じる
+    );     // showDialog を閉じる
 
     if (!mounted || result == null) {
       return;


### PR DESCRIPTION
## Summary
- annotate the showDialog builder closure in the person dialog helper to make the closing structure explicit

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da26f9f9648332a1186cfb3dd395b8