### PR TITLE
Adjust add person dialog button colors

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -833,11 +833,17 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
                         onPressed: _submitting
                             ? null
                             : () => Navigator.of(context).pop(),
+                        style: TextButton.styleFrom(
+                          foregroundColor: Colors.black,
+                        ),
                         child: const Text('キャンセル'),
                       ),
                       const SizedBox(width: 8),
                       ElevatedButton(
                         onPressed: _submitting ? null : () => _submit(),
+                        style: ElevatedButton.styleFrom(
+                          foregroundColor: Colors.black,
+                        ),
                         child: _submitting
                             ? SizedBox(
                                 height: 16,


### PR DESCRIPTION
## Summary
- set the cancel and save buttons in the add person dialog to use black text for consistency

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da32da9a508332a5354646e140f7e5