### PR TITLE
Align person avatar backgrounds across the app

### DIFF
--- a/lib/screens/expense/expense_detail_screen.dart
+++ b/lib/screens/expense/expense_detail_screen.dart
@@ -99,7 +99,7 @@ class ExpenseDetailScreen extends ConsumerWidget {
     return PersonAvatar(
       person: person,
       size: size,
-      backgroundColor: Colors.grey.shade200,
+      backgroundColor: kPersonAvatarBackgroundColor,
       textStyle: const TextStyle(
         fontSize: 28,
         fontWeight: FontWeight.bold,

--- a/lib/screens/expense/expense_form_sheet.dart
+++ b/lib/screens/expense/expense_form_sheet.dart
@@ -414,16 +414,15 @@ class _ExpenseFormSheetState extends ConsumerState<ExpenseFormSheet> {
   }
 
   Widget _buildPersonAvatar(Person person, {double size = 56}) {
-    final theme = Theme.of(context);
     return PersonAvatar(
       person: person,
       size: size,
       showShadow: true,
-      backgroundColor: theme.colorScheme.primaryContainer,
+      backgroundColor: kPersonAvatarBackgroundColor,
       textStyle: TextStyle(
         fontSize: size * 0.45,
         fontWeight: FontWeight.bold,
-        color: theme.colorScheme.onPrimaryContainer,
+        color: Theme.of(context).colorScheme.onSurface,
       ),
     );
   }

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -361,16 +361,15 @@ class _Avatar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const double size = 56;
-    final colorScheme = Theme.of(context).colorScheme;
     return PersonAvatar(
       person: summary.person,
       size: size,
       showShadow: true,
-      backgroundColor: colorScheme.primaryContainer,
+      backgroundColor: kPersonAvatarBackgroundColor,
       textStyle: TextStyle(
         fontSize: 24,
         fontWeight: FontWeight.bold,
-        color: colorScheme.onPrimaryContainer,
+        color: Theme.of(context).colorScheme.onSurface,
       ),
     );
   }

--- a/lib/screens/person/person_detail_screen.dart
+++ b/lib/screens/person/person_detail_screen.dart
@@ -364,7 +364,7 @@ class _PersonDetailScreenState
     return PersonAvatar(
       person: person,
       size: size,
-      backgroundColor: Colors.grey.shade200,
+      backgroundColor: kPersonAvatarBackgroundColor,
       textStyle: TextStyle(
         fontWeight: FontWeight.bold,
         fontSize: size * 0.45,

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -346,7 +346,7 @@ class _PersonManagementScreenState
     return PersonAvatar(
       person: person,
       size: 40,
-      backgroundColor: Colors.grey.shade200,
+      backgroundColor: kPersonAvatarBackgroundColor,
       textStyle: const TextStyle(
         fontSize: 20,
         fontWeight: FontWeight.bold,

--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -695,6 +695,7 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
     if (person == null) {
       return const CircleAvatar(
         radius: size / 2,
+        backgroundColor: kPersonAvatarBackgroundColor,
         child: Text('?', style: TextStyle(fontWeight: FontWeight.bold)),
       );
     }
@@ -702,7 +703,7 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
     return PersonAvatar(
       person: person,
       size: size,
-      backgroundColor: Colors.grey.shade300,
+      backgroundColor: kPersonAvatarBackgroundColor,
       textStyle: const TextStyle(fontWeight: FontWeight.bold),
     );
   }

--- a/lib/widgets/person_avatar.dart
+++ b/lib/widgets/person_avatar.dart
@@ -6,6 +6,8 @@ import 'package:characters/characters.dart';
 import '../models/person.dart';
 import '../utils/color_utils.dart';
 
+const Color kPersonAvatarBackgroundColor = Color(0xFFEEEEEE);
+
 class PersonAvatar extends StatelessWidget {
   const PersonAvatar({
     super.key,
@@ -73,13 +75,14 @@ class PersonAvatar extends StatelessWidget {
             ? person.name.characters.first
             : '?');
 
-    final Color resolvedBackground = backgroundColor ??
-        Theme.of(context).colorScheme.primaryContainer;
+    final theme = Theme.of(context);
+    final Color resolvedBackground =
+        backgroundColor ?? kPersonAvatarBackgroundColor;
     final TextStyle resolvedStyle = textStyle ??
         TextStyle(
           fontSize: size * 0.42,
           fontWeight: FontWeight.bold,
-          color: Theme.of(context).colorScheme.onPrimaryContainer,
+          color: theme.colorScheme.onSurface,
         );
 
     return SizedBox(


### PR DESCRIPTION
## Summary
- add a shared constant for the default person avatar background color
- update all person avatar usages to rely on the shared color for consistency
- tweak default avatar text color to maintain legibility on the new background

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da343c53f883328d49d7338c7ae9d4