### PR TITLE
Fix incorrect opacity helper in person avatar shadow

### DIFF
--- a/lib/widgets/person_avatar.dart
+++ b/lib/widgets/person_avatar.dart
@@ -39,7 +39,7 @@ class PersonAvatar extends StatelessWidget {
         shape: BoxShape.circle,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacityValue(0.1),
+            color: Colors.black.withOpacity(0.1),
             blurRadius: 6,
             offset: const Offset(0, 3),
           ),


### PR DESCRIPTION
## Summary
- replace the invalid `withOpacityValue` call with the correct `withOpacity` helper when building the person avatar shadow

## Testing
- not run (Flutter tooling is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68da3875e7d483328a77fc342e43c6e5