### PR TITLE
Fix missing closing brace in PersonAvatar

### DIFF
--- a/lib/widgets/person_avatar.dart
+++ b/lib/widgets/person_avatar.dart
@@ -97,3 +97,4 @@ class PersonAvatar extends StatelessWidget {
       ),
     );
   }
+}


### PR DESCRIPTION
## Summary
- add the missing closing brace for the `PersonAvatar` widget class to satisfy the analyzer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da3bca15e883328f60625f6e55a125