### PR TITLE
Adjust add person icon color

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -459,7 +459,10 @@ class _PersonManagementScreenState
             ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: _addPerson,
-        icon: const Icon(Icons.person_add),
+        icon: const Icon(
+          Icons.person_add,
+          color: Color(0xFF3366FF),
+        ),
         label: const Text(
           '人を追加',
           style: TextStyle(color: Colors.black),


### PR DESCRIPTION
## Summary
- update the add person floating action button icon to use the specified #3366FF color

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da3cfcc5ac83328ab2191b5c929846