### PR TITLE
Adjust filter dialog background color

### DIFF
--- a/lib/screens/person/person_detail_screen.dart
+++ b/lib/screens/person/person_detail_screen.dart
@@ -258,6 +258,7 @@ class _PersonDetailScreenState
       builder: (context) {
         return AlertDialog(
           title: const Text('フィルタ・並び替え'),
+          backgroundColor: const Color(0xFFFFFAF0),
           content: SingleChildScrollView(
             child: Column(
               mainAxisSize: MainAxisSize.min,

--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -276,9 +276,10 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
               }
             }
 
-              final selectedRange = tempRange;
-              return AlertDialog(
+            final selectedRange = tempRange;
+            return AlertDialog(
               title: const Text('フィルタ・並び替え'),
+              backgroundColor: const Color(0xFFFFFAF0),
               content: SingleChildScrollView(
                 child: Column(
                   mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## Summary
- update the filter/sort dialogs to use the #FFFAF0 background color on both the unpaid and person detail screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da3e37c07c8332a4e4e9d567ced487