### PR TITLE
Adjust filter dialog button text color

### DIFF
--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -446,7 +446,10 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
               actions: [
                 TextButton(
                   onPressed: () => Navigator.pop(context),
-                  child: const Text('キャンセル'),
+                  child: const Text(
+                    'キャンセル',
+                    style: TextStyle(color: Colors.black),
+                  ),
                 ),
                 ElevatedButton(
                   onPressed: () {
@@ -461,7 +464,10 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
                     });
                     Navigator.pop(context);
                   },
-                  child: const Text('適用'),
+                  child: const Text(
+                    '適用',
+                    style: TextStyle(color: Colors.black),
+                  ),
                 ),
               ],
             );


### PR DESCRIPTION
## Summary
- set the cancel and apply labels in the filter dialog to use black text for better readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da3fe6ac308332abd5d7dcd56a60ed