### PR TITLE
Adjust bottom navigation selection color

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -79,6 +79,7 @@ class _RootPageState extends ConsumerState<RootPage> {
       ),
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _index,
+        selectedItemColor: const Color(0xFF3366FF),
         onTap: (value) => setState(() => _index = value),
         items: const [
           BottomNavigationBarItem(


### PR DESCRIPTION
## Summary
- update the bottom navigation bar to use #3366FF for selected items

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da41a1fcdc8332ab402a6ec7e99c29