### PR TITLE
Set white background for selected photo avatar

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -748,6 +748,8 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
                     Center(
                       child: CircleAvatar(
                         radius: 40,
+                        backgroundColor:
+                            photoPreview != null ? Colors.white : null,
                         backgroundImage: photoPreview,
                         child: photoPreview == null
                             ? const Icon(Icons.person, size: 40)


### PR DESCRIPTION
## Summary
- set the add person dialog's photo avatar background to white when an image is selected

## Testing
- `flutter test` *(fails: Flutter SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da43a94f388332a51ce1550ef07f45