### PR TITLE
Make add person photo buttons black

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -776,6 +776,9 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
                           onPressed: _submitting
                               ? null
                               : () => _pickPhoto(ImageSource.gallery),
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: Colors.black,
+                          ),
                           icon: const Icon(Icons.photo_library),
                           label: const Text('アルバムから選択'),
                         ),
@@ -783,6 +786,9 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
                           onPressed: _submitting
                               ? null
                               : () => _pickPhoto(ImageSource.camera),
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: Colors.black,
+                          ),
                           icon: const Icon(Icons.photo_camera),
                           label: const Text('カメラで撮影'),
                         ),


### PR DESCRIPTION
## Summary
- ensure the add person photo selection buttons use a black foreground color for icons and text

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da444625f88332abd78b0101cdc231