### PR TITLE
Ensure photo option avatar uses white background

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -748,8 +748,7 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
                     Center(
                       child: CircleAvatar(
                         radius: 40,
-                        backgroundColor:
-                            photoPreview != null ? Colors.white : null,
+                        backgroundColor: _usePhoto ? Colors.white : null,
                         backgroundImage: photoPreview,
                         child: photoPreview == null
                             ? const Icon(Icons.person, size: 40)


### PR DESCRIPTION
## Summary
- ensure the add-person dialog uses a white background for the avatar whenever the photo option is active so the person icon stays visible

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da44dd4edc8332a5ff0da7e521f093