### PR TITLE
Set delete photo button text and icon to black

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -798,8 +798,17 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
                         if (_currentPhotoPath != null)
                           TextButton.icon(
                             onPressed: _submitting ? null : _removePhoto,
-                            icon: const Icon(Icons.delete_outline),
-                            label: const Text('写真を削除'),
+                            style: TextButton.styleFrom(
+                              foregroundColor: Colors.black,
+                            ),
+                            icon: const Icon(
+                              Icons.delete_outline,
+                              color: Colors.black,
+                            ),
+                            label: const Text(
+                              '写真を削除',
+                              style: TextStyle(color: Colors.black),
+                            ),
                           ),
                       ],
                     ),


### PR DESCRIPTION
## Summary
- ensure the delete photo button in the add person dialog uses black styling for both text and icon
- add button styling to keep the foreground color consistent

## Testing
- flutter test *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da4ccec29483328cc3d12a61e65587