### PR TITLE
Set selected filter chips to a white background

### DIFF
--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -296,6 +296,8 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
                         FilterChip(
                           label: const Text('全員'),
                           selected: tempPersonId == null,
+                          selectedColor: Colors.white,
+                          checkmarkColor: Colors.black87,
                           onSelected: (selected) {
                             setDialogState(() => tempPersonId = null);
                           },
@@ -304,6 +306,8 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
                           (person) => FilterChip(
                             label: Text(person.name),
                             selected: tempPersonId == person.id,
+                            selectedColor: Colors.white,
+                            checkmarkColor: Colors.black87,
                             onSelected: (selected) {
                               setDialogState(() {
                                 tempPersonId = selected ? person.id : null;


### PR DESCRIPTION
## Summary
- set the selected filter chips in the unpaid filter dialog to use a white background for better visibility

## Testing
- flutter test *(fails: Flutter is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da4e0d2a64833297f65feca3edbf30