### PR TITLE
Add border to photo delete button in person dialog

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -796,19 +796,14 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
                           label: const Text('カメラで撮影'),
                         ),
                         if (_currentPhotoPath != null)
-                          TextButton.icon(
+                          OutlinedButton.icon(
                             onPressed: _submitting ? null : _removePhoto,
-                            style: TextButton.styleFrom(
+                            style: OutlinedButton.styleFrom(
                               foregroundColor: Colors.black,
+                              side: const BorderSide(color: Colors.black),
                             ),
-                            icon: const Icon(
-                              Icons.delete_outline,
-                              color: Colors.black,
-                            ),
-                            label: const Text(
-                              '写真を削除',
-                              style: TextStyle(color: Colors.black),
-                            ),
+                            icon: const Icon(Icons.delete_outline),
+                            label: const Text('写真を削除'),
                           ),
                       ],
                     ),


### PR DESCRIPTION
## Summary
- replace the photo delete text button with an outlined button so it gains a black border
- keep the foreground color consistent with the other photo action buttons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da4eb4b31083328b377f4ce35daf0e