### PR TITLE
Add subtle border to selected person chips in filter dialog

### DIFF
--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -293,27 +293,47 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
                     Wrap(
                       spacing: 8,
                       children: [
-                        FilterChip(
-                          label: const Text('全員'),
-                          selected: tempPersonId == null,
-                          selectedColor: Colors.white,
-                          checkmarkColor: Colors.black87,
-                          onSelected: (selected) {
-                            setDialogState(() => tempPersonId = null);
-                          },
-                        ),
-                        ...people.map(
-                          (person) => FilterChip(
-                            label: Text(person.name),
-                            selected: tempPersonId == person.id,
+                        () {
+                          final isSelected = tempPersonId == null;
+                          return FilterChip(
+                            label: const Text('全員'),
+                            selected: isSelected,
                             selectedColor: Colors.white,
                             checkmarkColor: Colors.black87,
+                            shape: StadiumBorder(
+                              side: BorderSide(
+                                color: isSelected
+                                    ? Colors.black26
+                                    : Colors.transparent,
+                              ),
+                            ),
                             onSelected: (selected) {
-                              setDialogState(() {
-                                tempPersonId = selected ? person.id : null;
-                              });
+                              setDialogState(() => tempPersonId = null);
                             },
-                          ),
+                          );
+                        }(),
+                        ...people.map(
+                          (person) {
+                            final isSelected = tempPersonId == person.id;
+                            return FilterChip(
+                              label: Text(person.name),
+                              selected: isSelected,
+                              selectedColor: Colors.white,
+                              checkmarkColor: Colors.black87,
+                              shape: StadiumBorder(
+                                side: BorderSide(
+                                  color: isSelected
+                                      ? Colors.black26
+                                      : Colors.transparent,
+                                ),
+                              ),
+                              onSelected: (selected) {
+                                setDialogState(() {
+                                  tempPersonId = selected ? person.id : null;
+                                });
+                              },
+                            );
+                          },
                         ),
                       ],
                     ),


### PR DESCRIPTION
## Summary
- add a light outline to the selected "全員" filter chip in the filter/sort dialog
- add the same light outline to each selected person chip

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68da53c59d848332a2171fcb5afc498e