### PR TITLE
Update switch off state color

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -63,7 +63,7 @@ class HomeScreen extends ConsumerWidget {
                   value: includePlanned,
                   activeColor: Colors.white,
                   activeTrackColor: const Color(0xFF3366FF),
-                  inactiveTrackColor: const Color(0xFFCCCCCC),
+                  inactiveTrackColor: const Color(0xFFE0E0E0),
                   onChanged: (value) => ref
                       .read(includePlannedInSummaryProvider.notifier)
                       .state = value,

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -198,7 +198,7 @@ class _SettingsSwitchTile extends StatelessWidget {
       value: enabled ? value : false,
       activeColor: Colors.white,
       activeTrackColor: const Color(0xFF3366FF),
-      inactiveTrackColor: const Color(0xFFCCCCCC),
+      inactiveTrackColor: const Color(0xFFE0E0E0),
       onChanged: enabled ? onChanged : null,
       secondary: icon == null
           ? null


### PR DESCRIPTION
## Summary
- update the inactive track color for switches on the home and settings screens to #E0E0E0

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da6580e4648332976980ad43381328