### PR TITLE
Adjust switch inactive color

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -63,7 +63,7 @@ class HomeScreen extends ConsumerWidget {
                   value: includePlanned,
                   activeColor: Colors.white,
                   activeTrackColor: const Color(0xFF3366FF),
-                  inactiveTrackColor: const Color(0xFFE0E0E0),
+                  inactiveTrackColor: const Color(0xFFEEEEEE),
                   onChanged: (value) => ref
                       .read(includePlannedInSummaryProvider.notifier)
                       .state = value,

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -198,7 +198,7 @@ class _SettingsSwitchTile extends StatelessWidget {
       value: enabled ? value : false,
       activeColor: Colors.white,
       activeTrackColor: const Color(0xFF3366FF),
-      inactiveTrackColor: const Color(0xFFE0E0E0),
+      inactiveTrackColor: const Color(0xFFEEEEEE),
       onChanged: enabled ? onChanged : null,
       secondary: icon == null
           ? null


### PR DESCRIPTION
## Summary
- update the inactive track color of switches to #EEEEEE in the home and settings screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da6ea198dc83328042e826598dc84f