### PR TITLE
Adjust planned badge color on home screen cards

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -213,7 +213,7 @@ class _PersonSummaryTile extends ConsumerWidget {
                         const SizedBox(height: 4),
                         _CountBadge(
                           text: '予定${summary.plannedCount}件',
-                          color: colorScheme.secondary,
+                          color: const Color(0xFFEEEEEE),
                         ),
                       ],
                     ],
@@ -386,18 +386,29 @@ class _CountBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final badgeColor = color ?? Theme.of(context).colorScheme.primary;
+    final theme = Theme.of(context);
+    final badgeColor = color ?? theme.colorScheme.primary;
+    final isCustomColor = color != null;
+    final backgroundColor = isCustomColor
+        ? badgeColor
+        : badgeColor.withOpacityValue(0.12);
+    final borderColor = isCustomColor
+        ? Colors.transparent
+        : badgeColor.withOpacityValue(0.3);
+    final textColor = isCustomColor
+        ? theme.colorScheme.onSurface
+        : badgeColor;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-        decoration: BoxDecoration(
-          color: badgeColor.withOpacityValue(0.12),
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: badgeColor.withOpacityValue(0.3)),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: borderColor),
       ),
       child: Text(
         text,
         style: TextStyle(
-          color: badgeColor,
+          color: textColor,
           fontSize: 12,
           fontWeight: FontWeight.w600,
         ),


### PR DESCRIPTION
## Summary
- update the planned count badge on the home screen cards to use the requested #EEEEEE color
- ensure custom badge colors keep text legible by adjusting background, border, and text styling

## Testing
- `flutter test` *(fails: Flutter SDK not available in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da6fd778848332afcd585ab744016b