### PR TITLE
Restore home card unpaid badge colors

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -389,15 +389,15 @@ class _CountBadge extends StatelessWidget {
     final theme = Theme.of(context);
     final badgeColor = color ?? theme.colorScheme.primary;
     final isCustomColor = color != null;
-    final backgroundColor = isCustomColor
+    final useSolidStyle = isCustomColor &&
+        ThemeData.estimateBrightnessForColor(badgeColor) == Brightness.light;
+    final backgroundColor = useSolidStyle
         ? badgeColor
         : badgeColor.withOpacityValue(0.12);
-    final borderColor = isCustomColor
+    final borderColor = useSolidStyle
         ? Colors.transparent
         : badgeColor.withOpacityValue(0.3);
-    final textColor = isCustomColor
-        ? theme.colorScheme.onSurface
-        : badgeColor;
+    final textColor = useSolidStyle ? theme.colorScheme.onSurface : badgeColor;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       decoration: BoxDecoration(


### PR DESCRIPTION
## Summary
- restore the original tinted styling for unpaid badges on the home screen cards
- keep solid styling for very light custom colors so the planned badge remains legible

## Testing
- flutter test *(fails: Flutter is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da724245a08332bd669fa7db8fe3ee