### PR TITLE
Remove global label from unpaid total

### DIFF
--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -156,7 +156,7 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
         padding: const EdgeInsets.all(16),
         child: SafeArea(
           child: Text(
-            '未払い合計（全体）: ${formatCurrency(total)}',
+            '未払い合計: ${formatCurrency(total)}',
             style: TextStyle(
               fontSize: 18,
               fontWeight: FontWeight.bold,


### PR DESCRIPTION
## Summary
- remove the "（全体）" label from the unpaid total footer so only the amount remains

## Testing
- not run (UI text change)


------
https://chatgpt.com/codex/tasks/task_e_68da78b5fec88332b7cb2286d2480b4e