### PR TITLE
Replace bag emoji with grandpa icon for add person suggestions

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -510,7 +510,7 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
     '🐶',
     '🐱',
     '🎓',
-    '💼',
+    '👴',
   ];
 
   XFile? _selectedPhoto;


### PR DESCRIPTION
## Summary
- update the suggested emoji list on the add person dialog to show a grandpa icon instead of a bag

## Testing
- flutter test *(fails: Flutter SDK not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db36f7c50c833293b403a9cfc35af5