### PR TITLE
Update suggested emoji for person addition

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -509,7 +509,7 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
     '👵',
     '🐶',
     '🐱',
-    '🎓',
+    '👨‍🏫',
     '👴',
   ];
 


### PR DESCRIPTION
## Summary
- replace the doctoral cap emoji in the person icon suggestions with a male teacher icon to better match the requested design

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68db386a2db48332b00c2bf507e6c131