### PR TITLE
Remove divider below unpaid filter button

### DIFF
--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -135,7 +135,6 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
               ],
             ),
           ),
-          Divider(height: 1, color: Colors.grey[300]),
           Expanded(
             child: filteredExpenses.isEmpty
                 ? _buildEmptyState()


### PR DESCRIPTION
## Summary
- remove the separator below the filter button on the unpaid list screen to match the desired design

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db3cf5a7b48332be9b92dd48247284