### PR TITLE
Set person save button background to white

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -884,6 +884,7 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
                       ElevatedButton(
                         onPressed: _submitting ? null : () => _submit(),
                         style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.white,
                           foregroundColor: Colors.black,
                         ),
                         child: _submitting


### PR DESCRIPTION
## Summary
- update the save button styling on the person add/edit dialog so its background is white

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db45f1824c8332ba337e9c596961a7