### PR TITLE
Adjust text field focus styling to use dark gray

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,6 +38,23 @@ class PaymentCalendarApp extends ConsumerWidget {
           surface: const Color(0xFFFFFAF0),
         ),
         scaffoldBackgroundColor: const Color(0xFFFFFAF0),
+        inputDecorationTheme: InputDecorationTheme(
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: const BorderSide(color: Color(0xFFCCCCCC)),
+          ),
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: const BorderSide(color: Color(0xFFCCCCCC)),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: const BorderSide(color: Color(0xFF333333)),
+          ),
+        ),
+        textSelectionTheme: const TextSelectionThemeData(
+          cursorColor: Color(0xFF333333),
+        ),
         useMaterial3: true,
         fontFamily: 'N'
             'o'

--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -98,9 +98,6 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
                             },
                           )
                         : null,
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(8),
-                    ),
                   ),
                   onChanged: (value) => setState(() => searchQuery = value),
                 ),


### PR DESCRIPTION
## Summary
- add an app-wide InputDecorationTheme so focused borders use #333333 and default borders use #CCCCCC
- set the cursor color to #333333 via the text selection theme
- rely on the shared decoration for the unpaid search field

## Testing
- Not run (tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68db49681de88332a3492164436587e9