### PR TITLE
Adjust name field label color

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -702,6 +702,7 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
                     controller: _nameController,
                     decoration: const InputDecoration(
                       labelText: '名前',
+                      labelStyle: TextStyle(color: Colors.black87),
                       border: OutlineInputBorder(),
                     ),
                     validator: (value) {


### PR DESCRIPTION
## Summary
- add a labelStyle to the name TextFormField so its label renders with a dark color

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db4bd3482483329f0b6c0cbdde1168