### PR TITLE
Update app info dialog background color

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -120,15 +120,25 @@ class SettingsScreen extends ConsumerWidget {
   }
 
   void _showAppInfo(BuildContext context) {
-    showAboutDialog(
+    showDialog<void>(
       context: context,
-      applicationName: 'Payment Calendar',
-      applicationVersion: '1.0.0',
-      applicationIcon: const Icon(Icons.account_balance_wallet),
-      children: const [
-        SizedBox(height: 8),
-        Text('家族やグループの支払い予定と精算をまとめて管理できます。'),
-      ],
+      builder: (dialogContext) {
+        final theme = Theme.of(dialogContext);
+        return Theme(
+          data: theme.copyWith(
+            dialogBackgroundColor: const Color(0xFFFFFAF0),
+          ),
+          child: const AboutDialog(
+            applicationName: 'Payment Calendar',
+            applicationVersion: '1.0.0',
+            applicationIcon: Icon(Icons.account_balance_wallet),
+            children: [
+              SizedBox(height: 8),
+              Text('家族やグループの支払い予定と精算をまとめて管理できます。'),
+            ],
+          ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- wrap the app info dialog in a themed showDialog call
- set the dialog background color to #FFFAF0 to match the desired style

## Testing
- Not run (Flutter SDK not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbd4248a5c8332a39666834243f694