### PR TITLE
Set app info dialog background to eggshell

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -122,21 +122,16 @@ class SettingsScreen extends ConsumerWidget {
   void _showAppInfo(BuildContext context) {
     showDialog<void>(
       context: context,
-      builder: (dialogContext) {
-        final theme = Theme.of(dialogContext);
-        return Theme(
-          data: theme.copyWith(
-            dialogBackgroundColor: const Color(0xFFFFFAF0),
-          ),
-          child: const AboutDialog(
-            applicationName: 'Payment Calendar',
-            applicationVersion: '1.0.0',
-            applicationIcon: Icon(Icons.account_balance_wallet),
-            children: [
-              SizedBox(height: 8),
-              Text('家族やグループの支払い予定と精算をまとめて管理できます。'),
-            ],
-          ),
+      builder: (_) {
+        return const AboutDialog(
+          backgroundColor: Color(0xFFFFFAF0),
+          applicationName: 'Payment Calendar',
+          applicationVersion: '1.0.0',
+          applicationIcon: Icon(Icons.account_balance_wallet),
+          children: [
+            SizedBox(height: 8),
+            Text('家族やグループの支払い予定と精算をまとめて管理できます。'),
+          ],
         );
       },
     );


### PR DESCRIPTION
## Summary
- set the app info dialog background color to #FFFAF0 to match design request

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbd6f9e90c8332a00cf82c2b88a27d