### PR TITLE
Remove custom background color from app info dialog

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -124,7 +124,6 @@ class SettingsScreen extends ConsumerWidget {
       context: context,
       builder: (_) {
         return const AboutDialog(
-          backgroundColor: Color(0xFFFFFAF0),
           applicationName: 'Payment Calendar',
           applicationVersion: '1.0.0',
           applicationIcon: Icon(Icons.account_balance_wallet),


### PR DESCRIPTION
## Summary
- remove the custom background color override from the settings app info dialog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbdca994248332b8ba6bcd99dbdcbb