### PR TITLE
Update filter button color on unpaid screen

### DIFF
--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -109,8 +109,8 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
                       icon: const Icon(Icons.filter_list, size: 18),
                       label: const Text('フィルタ'),
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.blue[50],
-                        foregroundColor: Colors.blue[700],
+                        backgroundColor: const Color(0xFF3366FF),
+                        foregroundColor: Colors.white,
                         elevation: 0,
                       ),
                     ),


### PR DESCRIPTION
## Summary
- change the unpaid list screen filter button background to the requested #3366FF
- adjust the button foreground color to white for readability against the new background

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbe240c5d88332aa14a9aee8330a1f