### PR TITLE
Fix keyboard overflow in add person dialog

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -681,19 +681,23 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
   @override
   Widget build(BuildContext context) {
     final photoPreview = _buildPhotoPreview();
+    final bottomPadding = 24 + MediaQuery.of(context).viewInsets.bottom;
     return Dialog(
-      child: Container(
-        color: const Color(0xFFFFFAF0),
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 400),
-          child: Padding(
-            padding: const EdgeInsets.all(24),
-            child: Form(
-              key: _formKey,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
+      insetPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+      child: SafeArea(
+        child: SingleChildScrollView(
+          child: Container(
+            color: const Color(0xFFFFFAF0),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 400),
+              child: Padding(
+                padding: EdgeInsets.fromLTRB(24, 24, 24, bottomPadding),
+                child: Form(
+                  key: _formKey,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
                   Text(
                     widget.person == null ? '人を追加' : '人を編集',
                     style: Theme.of(context)


### PR DESCRIPTION
## Summary
- wrap the add person dialog content in a SafeArea and SingleChildScrollView with inset padding
- add keyboard inset-aware bottom padding to prevent overflow when the keyboard is visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd1ff0def4833294515240a35a87f3