### PR TITLE
Fix async context handling without BuildContext.mounted

### DIFF
--- a/lib/screens/expense/expense_detail_screen.dart
+++ b/lib/screens/expense/expense_detail_screen.dart
@@ -292,6 +292,7 @@ class ExpenseDetailScreen extends ConsumerWidget {
     WidgetRef ref,
     Expense expense,
   ) async {
+    final messenger = ScaffoldMessenger.of(context);
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (dialogContext) => AlertDialog(
@@ -312,10 +313,10 @@ class ExpenseDetailScreen extends ConsumerWidget {
 
     if (confirmed == true) {
       ref.read(expensesProvider.notifier).markAsPaid(expense.id);
-      if (!context.mounted) {
+      if (!messenger.mounted) {
         return;
       }
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         const SnackBar(
           content: Text('支払い済みにしました'),
           duration: Duration(seconds: 2),
@@ -329,6 +330,7 @@ class ExpenseDetailScreen extends ConsumerWidget {
     WidgetRef ref,
     Expense expense,
   ) async {
+    final messenger = ScaffoldMessenger.of(context);
     final picked = await showDatePicker(
       context: context,
       initialDate: expense.date,
@@ -338,10 +340,10 @@ class ExpenseDetailScreen extends ConsumerWidget {
 
     if (picked != null && picked != expense.date) {
       ref.read(expensesProvider.notifier).changeDate(expense.id, picked);
-      if (!context.mounted) {
+      if (!messenger.mounted) {
         return;
       }
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         const SnackBar(
           content: Text('期日を変更しました'),
           duration: Duration(seconds: 2),
@@ -355,6 +357,7 @@ class ExpenseDetailScreen extends ConsumerWidget {
     WidgetRef ref,
     Expense expense,
   ) async {
+    final messenger = ScaffoldMessenger.of(context);
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (dialogContext) => AlertDialog(
@@ -375,10 +378,10 @@ class ExpenseDetailScreen extends ConsumerWidget {
 
     if (confirmed == true) {
       ref.read(expensesProvider.notifier).markAsUnpaid(expense.id);
-      if (!context.mounted) {
+      if (!messenger.mounted) {
         return;
       }
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         const SnackBar(
           content: Text('未払いに戻しました'),
           duration: Duration(seconds: 2),
@@ -388,6 +391,7 @@ class ExpenseDetailScreen extends ConsumerWidget {
   }
 
   Future<void> _deleteExpense(BuildContext context, WidgetRef ref) async {
+    final navigator = Navigator.of(context);
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (dialogContext) => AlertDialog(
@@ -412,10 +416,10 @@ class ExpenseDetailScreen extends ConsumerWidget {
 
     if (confirmed == true) {
       ref.read(expensesProvider.notifier).deleteExpense(expenseId);
-      if (!context.mounted) {
+      if (!navigator.mounted) {
         return;
       }
-      Navigator.of(context).pop();
+      navigator.pop();
     }
   }
 

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -290,9 +290,10 @@ class _PersonSummaryTile extends ConsumerWidget {
       return false;
     }).toList();
 
+    final messenger = ScaffoldMessenger.of(context);
     if (targets.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('支払い対象の明細はありません')), 
+      messenger.showSnackBar(
+        const SnackBar(content: Text('支払い対象の明細はありません')),
       );
       return;
     }
@@ -326,7 +327,7 @@ class _PersonSummaryTile extends ConsumerWidget {
       return;
     }
 
-    if (!context.mounted) {
+    if (!messenger.mounted) {
       return;
     }
 
@@ -337,7 +338,6 @@ class _PersonSummaryTile extends ConsumerWidget {
           includePlanned: includePlannedForPayment,
         );
 
-    final messenger = ScaffoldMessenger.of(context);
     messenger.showSnackBar(
       SnackBar(
         content: Text(

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -40,14 +40,15 @@ class SettingsScreen extends ConsumerWidget {
                 value: settings.reminderEnabled,
                 icon: Icons.alarm,
                 onChanged: (value) async {
+                  final messenger = ScaffoldMessenger.of(context);
                   await ref
                       .read(settingsProvider.notifier)
                       .toggleReminder(value);
-                  if (!context.mounted) {
+                  if (!messenger.mounted) {
                     return;
                   }
                   if (value) {
-                    ScaffoldMessenger.of(context).showSnackBar(
+                    messenger.showSnackBar(
                       const SnackBar(
                         content: Text('リマインド通知を有効にしました'),
                         duration: Duration(seconds: 2),


### PR DESCRIPTION
## Summary
- cache ScaffoldMessenger and Navigator instances before awaiting dialogs so we no longer rely on `BuildContext.mounted`
- update expense detail, home, and settings screens to guard snack bar usage with state-specific `mounted` checks

## Testing
- not run (Flutter SDK is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd246e6d788332ad1187952fd1b77c