### PR TITLE
Ensure add person dialog uses floral white background

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -683,57 +683,61 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
   Widget build(BuildContext context) {
     final photoPreview = _buildPhotoPreview();
     final viewInsetsBottom = MediaQuery.of(context).viewInsets.bottom;
+    const backgroundColor = Color(0xFFFFFAF0);
     return Dialog(
+      backgroundColor: backgroundColor,
       insetPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
       child: SafeArea(
-        child: SingleChildScrollView(
-          padding: EdgeInsets.only(bottom: viewInsetsBottom),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Container(
-                color: const Color(0xFFFFFAF0),
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 400),
-                  child: Padding(
-                    padding: const EdgeInsets.fromLTRB(24, 24, 24, 24),
-                    child: Form(
-                      key: _formKey,
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            widget.person == null ? '人を追加' : '人を編集',
-                            style: Theme.of(context)
-                                .textTheme
-                                .titleLarge
-                                ?.copyWith(fontWeight: FontWeight.w600),
-                          ),
-                          const SizedBox(height: 24),
-                          TextFormField(
-                            controller: _nameController,
-                            decoration: const InputDecoration(
-                              labelText: '名前',
-                              labelStyle: TextStyle(color: Colors.black87),
-                              border: OutlineInputBorder(),
+        child: Container(
+          color: backgroundColor,
+          child: SingleChildScrollView(
+            padding: EdgeInsets.only(bottom: viewInsetsBottom),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  color: backgroundColor,
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 400),
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(24, 24, 24, 24),
+                      child: Form(
+                        key: _formKey,
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              widget.person == null ? '人を追加' : '人を編集',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .titleLarge
+                                  ?.copyWith(fontWeight: FontWeight.w600),
                             ),
-                            validator: (value) {
-                              if (value == null || value.trim().isEmpty) {
-                                return '名前を入力してください';
-                              }
-                              return null;
-                            },
-                          ),
-                          const SizedBox(height: 16),
-                          Text(
-                            'アイコンの種類',
-                            style: Theme.of(context)
-                                .textTheme
-                                .bodyMedium
-                                ?.copyWith(fontWeight: FontWeight.w600),
-                          ),
-                          const SizedBox(height: 8),
+                            const SizedBox(height: 24),
+                            TextFormField(
+                              controller: _nameController,
+                              decoration: const InputDecoration(
+                                labelText: '名前',
+                                labelStyle: TextStyle(color: Colors.black87),
+                                border: OutlineInputBorder(),
+                              ),
+                              validator: (value) {
+                                if (value == null || value.trim().isEmpty) {
+                                  return '名前を入力してください';
+                                }
+                                return null;
+                              },
+                            ),
+                            const SizedBox(height: 16),
+                            Text(
+                              'アイコンの種類',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodyMedium
+                                  ?.copyWith(fontWeight: FontWeight.w600),
+                            ),
+                            const SizedBox(height: 8),
                           Wrap(
                             spacing: 8,
                             children: [


### PR DESCRIPTION
## Summary
- set the add person dialog background color to Color(0xFFFFFAF0)
- ensure the SafeArea wrapper and scroll content use the same floral white color

## Testing
- dart format lib/screens/settings/settings_screen.dart *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd305915cc833295c6bf43bbb47085