### PR TITLE
Adjust person dialog layout for new design

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -687,13 +687,15 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
       insetPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
       child: SafeArea(
         child: SingleChildScrollView(
-          padding: EdgeInsets.only(bottom: 24 + viewInsetsBottom),
+          padding: EdgeInsets.only(bottom: viewInsetsBottom),
           child: Container(
             color: const Color(0xFFFFFAF0),
+            padding: const EdgeInsets.all(16),
             child: Form(
               key: _formKey,
               child: Column(
                 mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
                   ConstrainedBox(
                     constraints: const BoxConstraints(maxWidth: 400),
@@ -887,43 +889,37 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
                             ),
                           ],
                           const SizedBox(height: 24),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.end,
-                            children: [
-                              TextButton(
-                                onPressed: _submitting
-                                    ? null
-                                    : () => Navigator.of(context).pop(),
-                                style: TextButton.styleFrom(
-                                  foregroundColor: Colors.black,
-                                ),
-                                child: const Text('キャンセル'),
-                              ),
-                              const SizedBox(width: 8),
-                              ElevatedButton(
-                                onPressed: _submitting ? null : () => _submit(),
-                                style: ElevatedButton.styleFrom(
-                                  backgroundColor: Colors.white,
-                                  foregroundColor: Colors.black,
-                                ),
-                                child: _submitting
-                                    ? const SizedBox(
-                                        height: 16,
-                                        width: 16,
-                                        child: CircularProgressIndicator(
-                                          strokeWidth: 2,
-                                        ),
-                                      )
-                                    : const Text('保存'),
-                              ),
-                            ],
-                          ),
                         ],
                       ),
                     ),
                   ),
-                ),
-              ],
+                  const SizedBox(height: 16),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      TextButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: const Text('キャンセル'),
+                      ),
+                      const SizedBox(width: 8),
+                      ElevatedButton(
+                        onPressed: _submitting ? null : _submit,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.white,
+                          foregroundColor: Colors.black,
+                        ),
+                        child: _submitting
+                            ? const SizedBox(
+                                height: 16,
+                                width: 16,
+                                child: CircularProgressIndicator(strokeWidth: 2),
+                              )
+                            : const Text('保存'),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
## Summary
- adjust the person edit dialog to use the new SafeArea + SingleChildScrollView structure with consistent padding
- move the action buttons outside the constrained form content to follow the updated layout and loading state handling

## Testing
- Not run (Flutter/Dart tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd3eee733c8332a9d27c997a8c93b8