### PR TITLE
Update cancel button color in add person dialog

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -899,6 +899,9 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
                     children: [
                       TextButton(
                         onPressed: () => Navigator.of(context).pop(),
+                        style: TextButton.styleFrom(
+                          foregroundColor: Colors.black,
+                        ),
                         child: const Text('キャンセル'),
                       ),
                       const SizedBox(width: 8),


### PR DESCRIPTION
## Summary
- set the add person dialog cancel button text color to black to match the requested styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd4d07a05c83329d3b07a2fd1eff61