### PR TITLE
Ensure add person cancel button text uses black color

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -902,7 +902,10 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
                         style: TextButton.styleFrom(
                           foregroundColor: Colors.black,
                         ),
-                        child: const Text('キャンセル'),
+                        child: const Text(
+                          'キャンセル',
+                          style: TextStyle(color: Colors.black),
+                        ),
                       ),
                       const SizedBox(width: 8),
                       ElevatedButton(


### PR DESCRIPTION
## Summary
- ensure the cancel button text in the add person dialog uses an explicit black text color

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de3262f4b08332b61b7ca3fa47b44b