### PR TITLE
Set emoji input text color to black

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -846,6 +846,7 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
                                 hintText: '例: 😀',
                                 border: OutlineInputBorder(),
                               ),
+                              style: const TextStyle(color: Colors.black),
                               inputFormatters: const [],
                             ),
                             const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- ensure the emoji text field in the person add/edit dialog renders text in black for readability

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de350f89bc83328392cfe763326f1d