### PR TITLE
Fix emoji label color in settings screen

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -845,6 +845,7 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
                                 labelText: 'アイコン（絵文字）',
                                 hintText: '例: 😀',
                                 border: OutlineInputBorder(),
+                                labelStyle: TextStyle(color: Colors.black),
                               ),
                               style: const TextStyle(color: Colors.black),
                               inputFormatters: const [],


### PR DESCRIPTION
## Summary
- add a label style to the emoji icon text field so the label stays black

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de8c81bbbc833289b77885fa0638bc