### PR TITLE
Adjust expense detail edit button colors

### DIFF
--- a/lib/screens/expense/expense_detail_screen.dart
+++ b/lib/screens/expense/expense_detail_screen.dart
@@ -264,8 +264,11 @@ class ExpenseDetailScreen extends ConsumerWidget {
               Expanded(
                 child: OutlinedButton.icon(
                   onPressed: () => _openEditor(context),
-                  icon: const Icon(Icons.edit),
+                  icon: const Icon(Icons.edit, color: Colors.black),
                   label: const Text('編集'),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: Colors.black,
+                  ),
                 ),
               ),
               const SizedBox(width: 12),


### PR DESCRIPTION
## Summary
- update the expense detail edit button icon to use a black color
- apply a black foreground color style so the button label also renders in black

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dea17b07248332b77d113da00ae967