### PR TITLE
Set expense detail card background to white

### DIFF
--- a/lib/screens/expense/expense_detail_screen.dart
+++ b/lib/screens/expense/expense_detail_screen.dart
@@ -133,6 +133,7 @@ class ExpenseDetailScreen extends ConsumerWidget {
     return Padding(
       padding: const EdgeInsets.all(16),
       child: Card(
+        color: Colors.white,
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(


### PR DESCRIPTION
## Summary
- set the payment detail card on the expense detail screen to use a white background for consistency

## Testing
- Not run (Flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dea2537da08332a1e83c7f7b7ec303