### PR TITLE
Update unpaid status chip color

### DIFF
--- a/lib/screens/expense/expense_detail_screen.dart
+++ b/lib/screens/expense/expense_detail_screen.dart
@@ -497,7 +497,7 @@ class _StatusChip extends StatelessWidget {
     final String label;
     switch (status) {
       case ExpenseStatus.unpaid:
-        color = Colors.redAccent;
+        color = const Color(0xFFF44336);
         label = '未払い';
         break;
       case ExpenseStatus.planned:


### PR DESCRIPTION
## Summary
- change the unpaid status chip color to match the requested hex value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dea7f35a5c83328802e2634ccd62aa