### PR TITLE
Update app info dialog name

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -125,7 +125,7 @@ class SettingsScreen extends ConsumerWidget {
       context: context,
       builder: (_) {
         return const AboutDialog(
-          applicationName: 'Payment Calendar',
+          applicationName: 'Pay Check',
           applicationVersion: '1.0.0',
           applicationIcon: Icon(Icons.account_balance_wallet),
           children: [


### PR DESCRIPTION
## Summary
- update the app information dialog to display "Pay Check" instead of "Payment Calendar"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e108cb53e48332bf8c2908a52c602a