### PR TITLE
Adjust unpaid status chip color

### DIFF
--- a/lib/screens/expense/expense_detail_screen.dart
+++ b/lib/screens/expense/expense_detail_screen.dart
@@ -497,7 +497,7 @@ class _StatusChip extends StatelessWidget {
     final String label;
     switch (status) {
       case ExpenseStatus.unpaid:
-        color = const Color(0xFFF44336);
+        color = const Color(0xFFFF0033);
         label = '未払い';
         break;
       case ExpenseStatus.planned:


### PR DESCRIPTION
## Summary
- update the unpaid status chip color to match the requested #FF0033 branding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1197d590083329a8b2f4944c58962