### PR TITLE
Adjust person dialog background padding

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -687,10 +687,14 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
       insetPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
       child: SafeArea(
         child: SingleChildScrollView(
-          padding: EdgeInsets.only(bottom: viewInsetsBottom),
           child: Container(
             color: const Color(0xFFFFFAF0),
-            padding: const EdgeInsets.all(16),
+            padding: EdgeInsets.fromLTRB(
+              16,
+              16,
+              16,
+              16 + viewInsetsBottom,
+            ),
             child: Form(
               key: _formKey,
               child: Column(


### PR DESCRIPTION
## Summary
- ensure the person add/edit dialog applies the global #FFFAF0 background color via its container
- include the keyboard inset in the dialog padding so layout remains stable when the keyboard appears

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e11ca302f88332988bc5ae99979124