### PR TITLE
Add theme color selection screen

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:characters/characters.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
@@ -10,15 +9,16 @@ import '../../models/person.dart';
 import '../../providers/people_provider.dart';
 import '../../providers/settings_provider.dart';
 import '../../widgets/person_avatar.dart';
+import 'theme_color_screen.dart';
 
-const _themeColorOptions = <Color>[
-  Color(0xFF3366FF),
-  Color(0xFFFF6B6B),
-  Color(0xFFFFA000),
-  Color(0xFF2BB673),
-  Color(0xFF9C27B0),
-  Color(0xFF00B0FF),
-];
+String _resolveThemeColorName(Color color) {
+  for (final option in themeColorOptions) {
+    if (option.color.value == color.value) {
+      return option.name;
+    }
+  }
+  return 'カスタムカラー';
+}
 
 class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
@@ -42,34 +42,15 @@ class SettingsScreen extends ConsumerWidget {
           _SettingsSection(
             title: 'テーマカラー',
             children: [
-              Padding(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'アプリ全体のアクセントカラーを変更できます',
-                      style: Theme.of(context)
-                          .textTheme
-                          .bodyMedium
-                          ?.copyWith(color: Colors.grey.shade600),
-                    ),
-                    const SizedBox(height: 12),
-                    Wrap(
-                      spacing: 12,
-                      runSpacing: 12,
-                      children: [
-                        for (final color in _themeColorOptions)
-                          _ThemeColorOption(
-                            color: color,
-                            selected: color.value == settings.themeColor.value,
-                            onSelected: () => ref
-                                .read(settingsProvider.notifier)
-                                .setThemeColor(color),
-                          ),
-                      ],
-                    ),
-                  ],
+              _SettingsListTile(
+                title: 'テーマカラー',
+                subtitle: '現在: ${_resolveThemeColorName(settings.themeColor)}',
+                leadingIcon: Icons.palette,
+                accentColor: colorScheme.primary,
+                onTap: () => Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => const ThemeColorScreen(),
+                  ),
                 ),
               ),
             ],
@@ -302,47 +283,6 @@ class _SettingsListTile extends StatelessWidget {
             ),
       trailing: Icon(trailingIcon, color: Colors.grey.shade600),
       onTap: onTap,
-    );
-  }
-}
-
-class _ThemeColorOption extends StatelessWidget {
-  const _ThemeColorOption({
-    required this.color,
-    required this.selected,
-    required this.onSelected,
-  });
-
-  final Color color;
-  final bool selected;
-  final VoidCallback onSelected;
-
-  @override
-  Widget build(BuildContext context) {
-    final borderColor = selected
-        ? color
-        : Theme.of(context).colorScheme.outline.withOpacity(0.5);
-    return GestureDetector(
-      onTap: onSelected,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 200),
-        width: 44,
-        height: 44,
-        decoration: BoxDecoration(
-          color: color,
-          shape: BoxShape.circle,
-          border: Border.all(
-            color: borderColor,
-            width: selected ? 4 : 2,
-          ),
-        ),
-        child: selected
-            ? const Icon(
-                Icons.check,
-                color: Colors.white,
-              )
-            : null,
-      ),
     );
   }
 }

--- a/lib/screens/settings/theme_color_screen.dart
+++ b/lib/screens/settings/theme_color_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/settings_provider.dart';
+
+class ThemeColorOption {
+  const ThemeColorOption({
+    required this.name,
+    required this.color,
+  });
+
+  final String name;
+  final Color color;
+}
+
+const themeColorOptions = <ThemeColorOption>[
+  ThemeColorOption(name: 'ブルーデニム', color: Color(0xFF5D73E1)),
+  ThemeColorOption(name: 'ナチュラルウッド', color: Color(0xFFE8CFA9)),
+  ThemeColorOption(name: 'ディープブルー', color: Color(0xFF1A2947)),
+  ThemeColorOption(name: 'オレンジ', color: Color(0xFFFF9800)),
+  ThemeColorOption(name: '青', color: Color(0xFF3366FF)),
+  ThemeColorOption(name: '水色', color: Color(0xFF00BCD4)),
+  ThemeColorOption(name: '赤', color: Color(0xFFFF0033)),
+  ThemeColorOption(name: 'ワインレッド', color: Color(0xFFB71C1C)),
+  ThemeColorOption(name: 'ピンク', color: Color(0xFFFF80AB)),
+  ThemeColorOption(name: '緑', color: Color(0xFF4CAF50)),
+];
+
+class ThemeColorScreen extends ConsumerWidget {
+  const ThemeColorScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final settings = ref.watch(settingsProvider);
+    final selectedColorValue = settings.themeColor.value;
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFFFFAF0),
+      appBar: AppBar(
+        title: const Text('テーマカラー'),
+        backgroundColor: const Color(0xFFFFFAF0),
+        foregroundColor: Theme.of(context).colorScheme.onSurface,
+        elevation: 0,
+      ),
+      body: ListView.separated(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+        itemBuilder: (context, index) {
+          final option = themeColorOptions[index];
+          final isSelected = option.color.value == selectedColorValue;
+          return Card(
+            color: Colors.white,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: ListTile(
+              leading: Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: option.color,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              title: Text(
+                option.name,
+                style: const TextStyle(fontWeight: FontWeight.w600),
+              ),
+              trailing: isSelected
+                  ? Icon(
+                      Icons.check,
+                      color: Theme.of(context).colorScheme.primary,
+                    )
+                  : null,
+              onTap: () async {
+                await ref
+                    .read(settingsProvider.notifier)
+                    .setThemeColor(option.color);
+              },
+            ),
+          );
+        },
+        separatorBuilder: (_, __) => const SizedBox(height: 12),
+        itemCount: themeColorOptions.length,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated theme color selection screen that lists named swatches and highlights the active color
- update the settings screen to launch the selector and show the currently chosen theme color

## Testing
- not run (Flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1e2d432248332bcfb94617d595897