### PR TITLE
Reorder theme color section in settings

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -40,22 +40,6 @@ class SettingsScreen extends ConsumerWidget {
         padding: EdgeInsets.zero,
         children: [
           _SettingsSection(
-            title: 'テーマカラー',
-            children: [
-              _SettingsListTile(
-                title: 'テーマカラー',
-                subtitle: '現在: ${_resolveThemeColorName(settings.themeColor)}',
-                leadingIcon: Icons.palette,
-                accentColor: colorScheme.primary,
-                onTap: () => Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const ThemeColorScreen(),
-                  ),
-                ),
-              ),
-            ],
-          ),
-          _SettingsSection(
             title: 'リマインド設定',
             children: [
               _SettingsSwitchTile(
@@ -126,6 +110,22 @@ class SettingsScreen extends ConsumerWidget {
                 onTap: () => Navigator.of(context).push(
                   MaterialPageRoute<void>(
                     builder: (_) => const _PersonManagementScreen(),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          _SettingsSection(
+            title: 'テーマカラー',
+            children: [
+              _SettingsListTile(
+                title: 'テーマカラー',
+                subtitle: '現在: ${_resolveThemeColorName(settings.themeColor)}',
+                leadingIcon: Icons.palette,
+                accentColor: colorScheme.primary,
+                onTap: () => Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => const ThemeColorScreen(),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Summary
- move the theme color settings card below the people management section to match the desired order

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1e6d7c5588332884d28b27b38c789