### PR TITLE
Remove blue theme color option

### DIFF
--- a/lib/screens/settings/theme_color_screen.dart
+++ b/lib/screens/settings/theme_color_screen.dart
@@ -18,7 +18,6 @@ const themeColorOptions = <ThemeColorOption>[
   ThemeColorOption(name: 'ナチュラルウッド', color: Color(0xFFE8CFA9)),
   ThemeColorOption(name: 'ディープブルー', color: Color(0xFF1A2947)),
   ThemeColorOption(name: 'オレンジ', color: Color(0xFFFF9800)),
-  ThemeColorOption(name: '青', color: Color(0xFF3366FF)),
   ThemeColorOption(name: '水色', color: Color(0xFF00BCD4)),
   ThemeColorOption(name: '赤', color: Color(0xFFFF0033)),
   ThemeColorOption(name: 'ワインレッド', color: Color(0xFFB71C1C)),


### PR DESCRIPTION
## Summary
- remove the 青 (#3366FF) theme color option from the selectable theme colors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1ea9ee59c83328116ffe6dbf0c1dd