### PR TITLE
Adjust theme color app bar

### DIFF
--- a/lib/screens/settings/theme_color_screen.dart
+++ b/lib/screens/settings/theme_color_screen.dart
@@ -37,8 +37,8 @@ class ThemeColorScreen extends ConsumerWidget {
       backgroundColor: const Color(0xFFFFFAF0),
       appBar: AppBar(
         title: const Text('テーマカラー'),
-        backgroundColor: const Color(0xFFFFFAF0),
-        foregroundColor: Theme.of(context).colorScheme.onSurface,
+        backgroundColor: Theme.of(context).colorScheme.primary,
+        foregroundColor: Theme.of(context).colorScheme.onPrimary,
         elevation: 0,
       ),
       body: ListView.separated(


### PR DESCRIPTION
## Summary
- update the theme color screen AppBar to use the active theme primary color while keeping the scaffold background fixed
- align the AppBar foreground color with the theme's onPrimary color for readability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2219e14788332b52308a6089926be