### PR TITLE
Adjust people menu background color

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -526,6 +526,7 @@ class _PersonManagementScreenState
                       ),
                     ),
                     trailing: PopupMenuButton<String>(
+                      color: const Color(0xFFF2F2F2),
                       onSelected: (value) {
                         switch (value) {
                           case 'edit':


### PR DESCRIPTION
## Summary
- update the people management options menu to use the #F2F2F2 background color

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e24ef85b788332af8f8a584651ecbe