### PR TITLE
Set expense detail photo card background to white

### DIFF
--- a/lib/screens/expense/expense_detail_screen.dart
+++ b/lib/screens/expense/expense_detail_screen.dart
@@ -153,6 +153,7 @@ class ExpenseDetailScreen extends ConsumerWidget {
     return Padding(
       padding: const EdgeInsets.all(16),
       child: Card(
+        color: Colors.white,
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(


### PR DESCRIPTION
## Summary
- ensure the photo attachments card on the expense detail screen uses a white background to match the rest of the detail layout

## Testing
- flutter test *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e25b78dfe48332bb6ff1ecde8dbb02