### PR TITLE
Add expense categories and management tools

### DIFF
--- a/lib/models/expense.dart
+++ b/lib/models/expense.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import 'expense_category.dart';
+
 enum ExpenseStatus { unpaid, planned, paid }
 
 class Expense {
@@ -11,6 +13,7 @@ class Expense {
     required this.amount,
     required this.memo,
     required this.status,
+    required this.category,
     this.photoPaths = const <String>[],
     this.paidAt,
     required this.createdAt,
@@ -22,6 +25,7 @@ class Expense {
     required DateTime date,
     required int amount,
     String memo = '',
+    String? category,
     List<String> photoPaths = const <String>[],
   }) {
     final now = DateUtils.dateOnly(DateTime.now());
@@ -33,6 +37,9 @@ class Expense {
       amount: amount,
       memo: memo,
       status: status,
+      category: (category == null || category.isEmpty)
+          ? ExpenseCategory.fallback
+          : category,
       photoPaths: List<String>.unmodifiable(photoPaths),
       createdAt: DateTime.now(),
     );
@@ -44,6 +51,7 @@ class Expense {
   final int amount;
   final String memo;
   final ExpenseStatus status;
+  final String category;
   final List<String> photoPaths;
   final DateTime? paidAt;
   final DateTime createdAt;
@@ -59,6 +67,7 @@ class Expense {
     int? amount,
     String? memo,
     ExpenseStatus? status,
+    String? category,
     List<String>? photoPaths,
     DateTime? paidAt,
     DateTime? createdAt,
@@ -70,6 +79,7 @@ class Expense {
       amount: amount ?? this.amount,
       memo: memo ?? this.memo,
       status: status ?? this.status,
+      category: category ?? this.category,
       photoPaths: photoPaths != null
           ? List<String>.unmodifiable(photoPaths)
           : this.photoPaths,
@@ -114,6 +124,7 @@ class Expense {
         other.amount == amount &&
         other.memo == memo &&
         other.status == status &&
+        other.category == category &&
         listEquals(other.photoPaths, photoPaths) &&
         other.paidAt == paidAt &&
         other.createdAt == createdAt;
@@ -127,6 +138,7 @@ class Expense {
         amount,
         memo,
         status,
+        category,
         Object.hashAll(photoPaths),
         paidAt,
         createdAt,

--- a/lib/models/expense_category.dart
+++ b/lib/models/expense_category.dart
@@ -1,0 +1,13 @@
+class ExpenseCategory {
+  static const fallback = 'その他';
+
+  static const defaults = <String>[
+    '食費',
+    '交通費',
+    '日用品',
+    '衣服',
+    '趣味',
+    '医療費',
+    fallback,
+  ];
+}

--- a/lib/providers/categories_provider.dart
+++ b/lib/providers/categories_provider.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/expense_category.dart';
+import 'expenses_provider.dart';
+
+final categoriesProvider =
+    StateNotifierProvider<CategoriesNotifier, List<String>>((ref) {
+  return CategoriesNotifier(ref);
+});
+
+class CategoriesNotifier extends StateNotifier<List<String>> {
+  CategoriesNotifier(this._ref)
+      : super(List<String>.from(ExpenseCategory.defaults));
+
+  final Ref _ref;
+
+  bool addCategory(String name) {
+    final trimmed = name.trim();
+    if (trimmed.isEmpty || state.contains(trimmed)) {
+      return false;
+    }
+    final updated = [...state];
+    final fallbackIndex = updated.indexOf(ExpenseCategory.fallback);
+    if (fallbackIndex >= 0) {
+      updated.insert(fallbackIndex, trimmed);
+    } else {
+      updated.add(trimmed);
+    }
+    state = updated;
+    return true;
+  }
+
+  bool renameCategory(String original, String updatedName) {
+    if (original == ExpenseCategory.fallback) {
+      return false;
+    }
+    final trimmed = updatedName.trim();
+    if (trimmed.isEmpty || trimmed == original || state.contains(trimmed)) {
+      return false;
+    }
+    state = [
+      for (final category in state)
+        if (category == original) trimmed else category,
+    ];
+    _ref
+        .read(expensesProvider.notifier)
+        .replaceCategory(original, trimmed);
+    return true;
+  }
+
+  bool removeCategory(String name) {
+    if (name == ExpenseCategory.fallback) {
+      return false;
+    }
+    state = state.where((category) => category != name).toList();
+    _ref
+        .read(expensesProvider.notifier)
+        .replaceCategory(name, ExpenseCategory.fallback);
+    return true;
+  }
+}

--- a/lib/providers/expenses_provider.dart
+++ b/lib/providers/expenses_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
 
 import '../models/expense.dart';
+import '../models/expense_category.dart';
 
 final expensesProvider =
     StateNotifierProvider<ExpensesNotifier, List<Expense>>((ref) {
@@ -22,6 +23,7 @@ class ExpensesNotifier extends StateNotifier<List<Expense>> {
         date: now.subtract(const Duration(days: 2)),
         amount: 1560,
         memo: 'スーパーでの買い物',
+        category: ExpenseCategory.fallback,
       ),
       Expense.newRecord(
         id: uuid.v4(),
@@ -29,6 +31,7 @@ class ExpensesNotifier extends StateNotifier<List<Expense>> {
         date: now.subtract(const Duration(days: 1)),
         amount: 780,
         memo: '電車代',
+        category: ExpenseCategory.fallback,
       ),
       Expense.newRecord(
         id: uuid.v4(),
@@ -36,6 +39,7 @@ class ExpensesNotifier extends StateNotifier<List<Expense>> {
         date: now,
         amount: 2400,
         memo: '子どもの服',
+        category: ExpenseCategory.fallback,
       ),
       Expense.newRecord(
         id: uuid.v4(),
@@ -43,6 +47,7 @@ class ExpensesNotifier extends StateNotifier<List<Expense>> {
         date: now.add(const Duration(days: 3)),
         amount: 4200,
         memo: '美容院（予約）',
+        category: ExpenseCategory.fallback,
       ),
       Expense(
         id: uuid.v4(),
@@ -51,6 +56,7 @@ class ExpensesNotifier extends StateNotifier<List<Expense>> {
         amount: 3200,
         memo: 'ガソリン代',
         status: ExpenseStatus.paid,
+        category: ExpenseCategory.fallback,
         paidAt: DateTime.now().subtract(const Duration(days: 2)),
         createdAt: DateTime.now().subtract(const Duration(days: 7)),
       ),
@@ -64,6 +70,7 @@ class ExpensesNotifier extends StateNotifier<List<Expense>> {
     required DateTime date,
     required int amount,
     String memo = '',
+    String? category,
     List<String> photoPaths = const [],
   }) {
     final expense = Expense.newRecord(
@@ -72,6 +79,7 @@ class ExpensesNotifier extends StateNotifier<List<Expense>> {
       date: date,
       amount: amount,
       memo: memo,
+      category: category,
       photoPaths: photoPaths,
     );
     state = [...state, expense];
@@ -118,6 +126,16 @@ class ExpensesNotifier extends StateNotifier<List<Expense>> {
     state = [
       for (final e in state)
         if (e.id == id) e.adjustStatus(date: date) else e,
+    ];
+  }
+
+  void replaceCategory(String from, String to) {
+    if (from == to) {
+      return;
+    }
+    state = [
+      for (final e in state)
+        if (e.category == from) e.copyWith(category: to) else e,
     ];
   }
 

--- a/lib/screens/expense/expense_detail_screen.dart
+++ b/lib/screens/expense/expense_detail_screen.dart
@@ -110,6 +110,9 @@ class ExpenseDetailScreen extends ConsumerWidget {
   Widget _buildDetailInfo(BuildContext context, Expense expense) {
     final rows = <Widget>[
       _InfoRow(label: '日付', value: formatDate(expense.date)),
+      const SizedBox(height: 12),
+      _InfoRow(label: 'カテゴリー', value: expense.category),
+      const SizedBox(height: 12),
       _InfoRow(label: '金額', value: formatCurrency(expense.amount)),
     ];
 

--- a/lib/screens/unpaid/unpaid_screen.dart
+++ b/lib/screens/unpaid/unpaid_screen.dart
@@ -86,7 +86,7 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
                 TextField(
                   controller: _searchController,
                   decoration: InputDecoration(
-                    hintText: 'メモや人名で検索...',
+                    hintText: 'メモ・カテゴリーや人名で検索...',
                     prefixIcon: const Icon(Icons.search),
                     suffixIcon: searchQuery.isNotEmpty
                         ? IconButton(
@@ -183,9 +183,12 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
     final query = searchQuery.trim().toLowerCase();
     if (query.isNotEmpty) {
       final memo = expense.memo.toLowerCase();
+      final category = expense.category.toLowerCase();
       final personName =
           peopleMap[expense.personId]?.name.toLowerCase() ?? '';
-      if (!memo.contains(query) && !personName.contains(query)) {
+      if (!memo.contains(query) &&
+          !personName.contains(query) &&
+          !category.contains(query)) {
         return false;
       }
     }
@@ -656,7 +659,7 @@ class _UnpaidScreenState extends ConsumerState<UnpaidScreen> {
             const SizedBox(width: 12),
             Expanded(
               child: Text(
-                expense.memo.isEmpty ? '記録' : expense.memo,
+                expense.category,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 style: const TextStyle(


### PR DESCRIPTION
## Summary
- add a category field to expenses with default category definitions and notifier support
- surface category selection on the expense form, show categories in details and unpaid lists, and shrink the memo field
- add a settings section for managing categories including add, edit, and delete actions

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2627901648332a60af5b3db232390