### PR TITLE
Set category addition dialog background color to #FFFAF0

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -582,6 +582,7 @@ class _CategoryFormDialogState extends State<_CategoryFormDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
+      backgroundColor: const Color(0xFFFFFAF0),
       title: Text(_isEditing ? 'カテゴリーを編集' : 'カテゴリーを追加'),
       content: TextField(
         controller: _controller,


### PR DESCRIPTION
## Summary
- set the category addition dialog background color to #FFFAF0 to match the requested styling

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e271a475a48332aa477ffc51b0b5d4