### PR TITLE
Remove optional marker from category label on expense form

### DIFF
--- a/lib/screens/expense/expense_form_sheet.dart
+++ b/lib/screens/expense/expense_form_sheet.dart
@@ -298,7 +298,7 @@ class _ExpenseFormSheetState extends ConsumerState<ExpenseFormSheet> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'カテゴリー（任意）',
+          'カテゴリー',
           style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
         ),
         const SizedBox(height: 8),


### PR DESCRIPTION
## Summary
- remove the optional marker from the category label in the expense form sheet so the label simply reads "カテゴリー"

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2725d51a083328124b4a0750b1e5b