### PR TITLE
Rename blue denim theme label

### DIFF
--- a/lib/screens/settings/theme_color_screen.dart
+++ b/lib/screens/settings/theme_color_screen.dart
@@ -14,7 +14,7 @@ class ThemeColorOption {
 }
 
 const themeColorOptions = <ThemeColorOption>[
-  ThemeColorOption(name: 'ブルーデニム', color: Color(0xFF3366FF)),
+  ThemeColorOption(name: 'ロイヤルブルー', color: Color(0xFF3366FF)),
   ThemeColorOption(name: 'ナチュラルウッド', color: Color(0xFFE8CFA9)),
   ThemeColorOption(name: 'ディープブルー', color: Color(0xFF1A2947)),
   ThemeColorOption(name: 'オレンジ', color: Color(0xFFFF9800)),


### PR DESCRIPTION
## Summary
- rename the theme color option label from ブルーデニム to ロイヤルブルー while keeping the color value unchanged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e296e122a083329ae2880f78ffcced