### PR TITLE
Add icons for expense categories

### DIFF
--- a/lib/screens/expense/expense_form_sheet.dart
+++ b/lib/screens/expense/expense_form_sheet.dart
@@ -11,6 +11,7 @@ import '../../models/expense_category.dart';
 import '../../providers/categories_provider.dart';
 import '../../providers/expenses_provider.dart';
 import '../../providers/people_provider.dart';
+import '../../utils/category_visuals.dart';
 import '../../utils/date_util.dart';
 import '../../widgets/person_avatar.dart';
 
@@ -305,11 +306,26 @@ class _ExpenseFormSheetState extends ConsumerState<ExpenseFormSheet> {
         DropdownButtonFormField<String>(
           value: effectiveValue,
           items: [
-            for (final category in categories)
-              DropdownMenuItem<String>(
-                value: category,
-                child: Text(category),
-              ),
+              for (final category in categories)
+                DropdownMenuItem<String>(
+                  value: category,
+                  child: Builder(
+                    builder: (context) {
+                      final visual = categoryVisualFor(category);
+                      return Row(
+                        children: [
+                          Icon(
+                            visual.icon,
+                            color: visual.color,
+                            size: 20,
+                          ),
+                          const SizedBox(width: 8),
+                          Text(category),
+                        ],
+                      );
+                    },
+                  ),
+                ),
           ],
           decoration: const InputDecoration(
             hintText: '選択しない場合は「その他」になります',

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -11,6 +11,7 @@ import '../../providers/categories_provider.dart';
 import '../../providers/people_provider.dart';
 import '../../providers/settings_provider.dart';
 import '../../widgets/person_avatar.dart';
+import '../../utils/category_visuals.dart';
 import 'theme_color_screen.dart';
 
 String _resolveThemeColorName(Color color) {
@@ -495,10 +496,16 @@ class _CategoryManagementScreenState
         itemBuilder: (context, index) {
           final category = categories[index];
           final isFallback = category == ExpenseCategory.fallback;
+          final visual = categoryVisualFor(category);
           return Card(
             margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
             color: Colors.white,
             child: ListTile(
+              leading: CircleAvatar(
+                backgroundColor: visual.color.withOpacity(0.15),
+                foregroundColor: visual.color,
+                child: Icon(visual.icon),
+              ),
               title: Text(category,
                   style: const TextStyle(fontWeight: FontWeight.w600)),
               subtitle: isFallback

--- a/lib/utils/category_visuals.dart
+++ b/lib/utils/category_visuals.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+class CategoryVisual {
+  const CategoryVisual({required this.icon, required this.color});
+
+  final IconData icon;
+  final Color color;
+}
+
+CategoryVisual categoryVisualFor(String category) {
+  switch (category) {
+    case '食費':
+      return const CategoryVisual(
+        icon: Icons.restaurant,
+        color: Colors.orange,
+      );
+    case '交通費':
+      return const CategoryVisual(
+        icon: Icons.train,
+        color: Colors.indigo,
+      );
+    case '日用品':
+      return const CategoryVisual(
+        icon: Icons.shopping_bag,
+        color: Colors.teal,
+      );
+    case '衣服':
+      return const CategoryVisual(
+        icon: Icons.checkroom,
+        color: Colors.purple,
+      );
+    case '趣味':
+      return const CategoryVisual(
+        icon: Icons.book,
+        color: Colors.blue,
+      );
+    case '医療費':
+      return const CategoryVisual(
+        icon: Icons.local_hospital,
+        color: Colors.red,
+      );
+    default:
+      return const CategoryVisual(
+        icon: Icons.category,
+        color: Colors.grey,
+      );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a utility that defines representative icons and colors for each default expense category
- show the category icons in the category management list
- display the same icons inside the category selector dropdown in the expense form

## Testing
- not run (flutter tooling is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e29bb268888332b732d9cd9366fd53