### PR TITLE
Update photo_manager to latest 3.x release

### DIFF
--- a/lib/screens/common/custom_photo_picker_screen.dart
+++ b/lib/screens/common/custom_photo_picker_screen.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:photo_manager/photo_manager.dart';
+import 'package:photo_manager_image_provider/photo_manager_image_provider.dart';
 
 class CustomPhotoPickerScreen extends StatefulWidget {
   const CustomPhotoPickerScreen({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,8 @@ dependencies:
   multi_dropdown:
     path: packages/multi_dropdown
   shared_preferences: ^2.2.2
-  photo_manager: ^2.8.1
+  photo_manager: ^3.0.0
+  photo_manager_image_provider: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- bump the photo_manager dependency to the 3.x line and add the companion image provider package
- update the custom photo picker to import the new image provider source for AssetEntityImage

## Testing
- flutter clean *(fails: Flutter SDK is not available in the execution environment)*
- flutter pub get *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e33e0f68588332b2c6987b85937dad