### PR TITLE
Add child preset avatar image

### DIFF
--- a/lib/widgets/person_avatar.dart
+++ b/lib/widgets/person_avatar.dart
@@ -117,13 +117,16 @@ class PersonAvatar extends StatelessWidget {
 
 enum _PresetAvatarType {
   mother,
-  father;
+  father,
+  child;
   static _PresetAvatarType? fromPerson(Person person) {
     switch (person.id) {
       case 'mother':
         return _PresetAvatarType.mother;
       case 'father':
         return _PresetAvatarType.father;
+      case 'child':
+        return _PresetAvatarType.child;
     }
     return null;
   }
@@ -152,6 +155,9 @@ class _PresetPersonAvatar extends StatelessWidget {
         break;
       case _PresetAvatarType.father:
         assetName = 'assets/images/father.png';
+        break;
+      case _PresetAvatarType.child:
+        assetName = 'assets/images/children.png';
         break;
     }
 


### PR DESCRIPTION
## Summary
- add a preset avatar configuration for the child profile
- display the bundled child photo instead of the emoji when no custom photo is provided

## Testing
- ⚠️ `flutter test` *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e366545c5c833292fb600182c3ae87