### PR TITLE
Handle Android photo permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Android 13 以降 -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+
+    <!-- Android 12 以前 -->
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+
     <application
         android:label="payment_calendar"
         android:name="${applicationName}"

--- a/lib/screens/expense/expense_form_sheet.dart
+++ b/lib/screens/expense/expense_form_sheet.dart
@@ -15,6 +15,7 @@ import '../../utils/category_visuals.dart';
 import '../../utils/date_util.dart';
 import '../../widgets/person_avatar.dart';
 import '../common/custom_photo_picker_screen.dart';
+import '../../utils/photo_permission_mixin.dart';
 
 class ExpenseFormSheet extends ConsumerStatefulWidget {
   const ExpenseFormSheet({super.key, this.expenseId});
@@ -25,7 +26,8 @@ class ExpenseFormSheet extends ConsumerStatefulWidget {
   ConsumerState<ExpenseFormSheet> createState() => _ExpenseFormSheetState();
 }
 
-class _ExpenseFormSheetState extends ConsumerState<ExpenseFormSheet> {
+class _ExpenseFormSheetState extends ConsumerState<ExpenseFormSheet>
+    with PhotoPermissionMixin<ExpenseFormSheet> {
   final _formKey = GlobalKey<FormState>();
   final _amountController = TextEditingController();
   final _memoController = TextEditingController();
@@ -504,6 +506,11 @@ class _ExpenseFormSheetState extends ConsumerState<ExpenseFormSheet> {
   }
 
   Future<void> _pickImages() async {
+    final hasPermission = await ensurePhotoAccessPermission();
+    if (!hasPermission) {
+      return;
+    }
+
     if (_photoPaths.length >= 5) {
       _showMessage('写真は最大5枚まで添付できます');
       return;

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -12,6 +12,7 @@ import '../../providers/people_provider.dart';
 import '../../providers/settings_provider.dart';
 import '../../widgets/person_avatar.dart';
 import '../../utils/category_visuals.dart';
+import '../../utils/photo_permission_mixin.dart';
 import '../common/custom_photo_picker_screen.dart';
 import 'theme_color_screen.dart';
 
@@ -868,7 +869,8 @@ class _PersonEditDialog extends StatefulWidget {
   State<_PersonEditDialog> createState() => _PersonEditDialogState();
 }
 
-class _PersonEditDialogState extends State<_PersonEditDialog> {
+class _PersonEditDialogState extends State<_PersonEditDialog>
+    with PhotoPermissionMixin<_PersonEditDialog> {
   late final TextEditingController _nameController;
   late final TextEditingController _emojiController;
   final _formKey = GlobalKey<FormState>();
@@ -933,6 +935,11 @@ class _PersonEditDialogState extends State<_PersonEditDialog> {
   }
 
   Future<void> _pickPhotoFromGallery() async {
+    final hasPermission = await ensurePhotoAccessPermission();
+    if (!hasPermission) {
+      return;
+    }
+
     try {
       final files = await Navigator.of(context).push<List<XFile>>(
         MaterialPageRoute<List<XFile>>(

--- a/lib/utils/photo_permission_mixin.dart
+++ b/lib/utils/photo_permission_mixin.dart
@@ -1,0 +1,82 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+mixin PhotoPermissionMixin<T extends StatefulWidget> on State<T> {
+  Future<bool> ensurePhotoAccessPermission() async {
+    if (!Platform.isAndroid && !Platform.isIOS) {
+      return true;
+    }
+
+    final List<Permission> permissions = <Permission>[
+      if (Platform.isAndroid) Permission.photos,
+      if (Platform.isAndroid) Permission.storage,
+      if (Platform.isIOS) Permission.photos,
+    ];
+
+    final List<PermissionStatus> currentStatuses = <PermissionStatus>[];
+    for (final Permission permission in permissions) {
+      currentStatuses.add(await permission.status);
+    }
+
+    if (_hasSufficientPermission(currentStatuses)) {
+      return true;
+    }
+
+    final Map<Permission, PermissionStatus> requestedStatuses =
+        await permissions.request();
+    final Iterable<PermissionStatus> results = requestedStatuses.values;
+
+    if (_hasSufficientPermission(results)) {
+      return true;
+    }
+
+    final bool permanentlyDenied = results.any(
+      (PermissionStatus status) => status.isPermanentlyDenied,
+    );
+
+    if (!mounted) {
+      return false;
+    }
+
+    await _showPermissionDialog(permanentlyDenied: permanentlyDenied);
+    return false;
+  }
+
+  bool _hasSufficientPermission(Iterable<PermissionStatus> statuses) {
+    return statuses.any(
+      (PermissionStatus status) =>
+          status.isGranted || status == PermissionStatus.limited,
+    );
+  }
+
+  Future<void> _showPermissionDialog({required bool permanentlyDenied}) async {
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext dialogContext) {
+        return AlertDialog(
+          title: const Text('写真へのアクセス権限が必要です'),
+          content: Text(
+            permanentlyDenied
+                ? '写真を選択するには、設定画面から写真へのアクセスを許可してください。'
+                : '写真を選択するには、写真へのアクセス権限を許可してください。',
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('キャンセル'),
+            ),
+            TextButton(
+              onPressed: () async {
+                Navigator.of(dialogContext).pop();
+                await openAppSettings();
+              },
+              child: const Text('設定を開く'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   shared_preferences: ^2.2.2
   photo_manager: ^3.0.0
   photo_manager_image_provider: ^2.0.0
+  permission_handler: ^11.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add Android 13 and legacy photo read permissions to the manifest
- add a reusable helper to request gallery access and guide the user to settings when denied
- ensure gallery pickers in expense and settings flows request permission before opening

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3f2981bb8833280b2944c9844ae43