### PR TITLE
Fix photo permission handling for photo_manager 3.x

### DIFF
--- a/lib/utils/photo_permission_mixin.dart
+++ b/lib/utils/photo_permission_mixin.dart
@@ -15,7 +15,9 @@ mixin PhotoPermissionMixin<T extends StatefulWidget> on State<T> {
       return true;
     }
 
-    final bool permanentlyDenied = result == PermissionState.deniedForever;
+    // Treat any non-authorized result as a permanently denied state so that
+    // we instruct the user to enable the permission from settings.
+    final bool permanentlyDenied = !result.isAuth;
 
     if (!mounted) {
       return false;


### PR DESCRIPTION
## Summary
- update photo permission mixin to determine denial states without relying on the removed `PermissionState.deniedForever`
- treat non-authorized permission requests as permanently denied so users are prompted to enable access in settings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e475129ae88332b4d08f544f6a0fb1