### PR TITLE
Handle Android 13 photo picker permissions

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -935,6 +935,11 @@ class _PersonEditDialogState extends State<_PersonEditDialog>
   }
 
   Future<void> _pickPhotoFromGallery() async {
+    if (await shouldUseAndroidPhotoPicker()) {
+      await _pickPhotoWithAndroidPhotoPicker();
+      return;
+    }
+
     final hasPermission = await ensurePhotoAccessPermission();
     if (!hasPermission) {
       return;
@@ -952,6 +957,31 @@ class _PersonEditDialogState extends State<_PersonEditDialog>
       }
       setState(() {
         _selectedPhoto = files.first;
+        _existingPhotoPath = null;
+        _usePhoto = true;
+        _showPhotoError = false;
+      });
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('写真の取得に失敗しました')),
+      );
+    }
+  }
+
+  Future<void> _pickPhotoWithAndroidPhotoPicker() async {
+    try {
+      final picked = await _picker.pickImage(source: ImageSource.gallery);
+      if (picked == null) {
+        return;
+      }
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _selectedPhoto = picked;
         _existingPhotoPath = null;
         _usePhoto = true;
         _showPhotoError = false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   photo_manager: ^3.0.0
   photo_manager_image_provider: ^2.0.0
   permission_handler: ^11.0.1
+  device_info_plus: ^9.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- skip explicit storage permission requests on Android 13+ and reuse existing dialogs for older platforms
- add device_info_plus dependency and expose helper to detect when to use the Android photo picker
- update expense and settings screens to launch the system photo picker on Android 13+ while keeping the legacy flow elsewhere

## Testing
- Unable to run `flutter pub get` (flutter not installed in container)

------
https://chatgpt.com/codex/tasks/task_e_68e5e7e1031c8332ac668e529729e868