### PR TITLE
Fix Android SDK lookup in photo permission mixin

### DIFF
--- a/lib/utils/photo_permission_mixin.dart
+++ b/lib/utils/photo_permission_mixin.dart
@@ -67,7 +67,8 @@ mixin PhotoPermissionMixin<T extends StatefulWidget> on State<T> {
 
   Future<int?> _getAndroidSdkInt() async {
     try {
-      final androidInfo = await DeviceInfoPlugin().androidInfo;
+      final deviceInfo = DeviceInfoPlugin();
+      final androidInfo = await deviceInfo.androidInfo;
       return androidInfo.version.sdkInt;
     } catch (_) {
       return null;


### PR DESCRIPTION
## Summary
- initialize a `DeviceInfoPlugin` instance before retrieving the Android SDK version in the photo permission mixin

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5f59507cc83328fc4af43a539f9fc