### PR TITLE
Ensure white background for date picker

### DIFF
--- a/lib/screens/expense/expense_detail_screen.dart
+++ b/lib/screens/expense/expense_detail_screen.dart
@@ -8,6 +8,7 @@ import '../../models/person.dart';
 import '../../providers/expenses_provider.dart';
 import '../../providers/people_provider.dart';
 import '../../utils/color_utils.dart';
+import '../../utils/date_picker_theme.dart';
 import '../../utils/date_util.dart';
 import '../../widgets/person_avatar.dart';
 import 'expense_form_sheet.dart';
@@ -344,6 +345,7 @@ class ExpenseDetailScreen extends ConsumerWidget {
       initialDate: expense.date,
       firstDate: DateTime.now().subtract(const Duration(days: 365)),
       lastDate: DateTime.now().add(const Duration(days: 365)),
+      builder: whiteDatePickerBuilder,
     );
 
     if (picked != null && picked != expense.date) {

--- a/lib/screens/expense/expense_form_sheet.dart
+++ b/lib/screens/expense/expense_form_sheet.dart
@@ -12,6 +12,7 @@ import '../../providers/categories_provider.dart';
 import '../../providers/expenses_provider.dart';
 import '../../providers/people_provider.dart';
 import '../../utils/category_visuals.dart';
+import '../../utils/date_picker_theme.dart';
 import '../../utils/date_util.dart';
 import '../../widgets/person_avatar.dart';
 import '../common/custom_photo_picker_screen.dart';
@@ -499,6 +500,7 @@ class _ExpenseFormSheetState extends ConsumerState<ExpenseFormSheet>
       initialDate: _selectedDate,
       firstDate: DateTime.now().subtract(const Duration(days: 365)),
       lastDate: DateTime.now().add(const Duration(days: 365)),
+      builder: whiteDatePickerBuilder,
     );
     if (picked != null) {
       setState(() => _selectedDate = picked);

--- a/lib/utils/date_picker_theme.dart
+++ b/lib/utils/date_picker_theme.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+Widget whiteDatePickerBuilder(BuildContext context, Widget? child) {
+  if (child == null) {
+    return const SizedBox.shrink();
+  }
+
+  final theme = Theme.of(context);
+  final colorScheme = theme.colorScheme;
+
+  final whiteColorScheme = colorScheme.copyWith(
+    surface: Colors.white,
+    background: Colors.white,
+  );
+
+  final datePickerTheme = theme.datePickerTheme.copyWith(
+    backgroundColor: Colors.white,
+    surfaceTintColor: Colors.transparent,
+  );
+
+  return Theme(
+    data: theme.copyWith(
+      colorScheme: whiteColorScheme,
+      datePickerTheme: datePickerTheme,
+      dialogBackgroundColor: Colors.white,
+    ),
+    child: child,
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable builder that forces the Material 3 date picker dialog to use a white background
- apply the builder to the expense form and detail flows so the calendar stays white regardless of app theme

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e63dc76c9083328ed5fabae0c209cc