### PR TITLE
ホーム画面のサブ説明文言を「家族や同居人」に変更

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -149,7 +149,7 @@ class _SampleExperience extends StatelessWidget {
         ),
         const SizedBox(height: 8),
         Text(
-          '右下の＋ボタンから記録を作成して、家族やパートナーとのお金のやり取りを管理しましょう。',
+          '右下の＋ボタンから記録を作成して、家族や同居人とのお金のやり取りを管理しましょう。',
           style: textTheme.bodyMedium?.copyWith(
             color: colorScheme.onSurfaceVariant,
           ),


### PR DESCRIPTION
### Motivation
- ホーム画面のサンプル表示文言で使われている「家族やパートナー」を、要件に合わせて「家族や同居人」に修正するため。 

### Description
- `lib/screens/home/home_screen.dart` 内のサンプル説明テキストを `"右下の＋ボタンから記録を作成して、家族やパートナーとのお金のやり取りを管理しましょう。"` から `"右下の＋ボタンから記録を作成して、家族や同居人とのお金のやり取りを管理しましょう。"` に差し替えただけで、レイアウト・挙動・他の文言には変更を加えていません。 

### Testing
- 自動テストは実行しておらず、変更は文言のみであるため UI や動作に影響を与えない想定です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980b2a2e088833287992e5975c107c5)